### PR TITLE
Version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+      - "-s -w -X github.com/google/gke-policy-automation/internal/app.Version={{.Version}} -X main.version={{.Version}} -X main.commit={{.Commit}}"
     goos:
       - freebsd
       - windows

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,14 +15,22 @@
 GOCMD		=go
 TEST		?=$$(go list ./... |grep -v 'vendor')
 BINARY		=gke-policy
+APP_MODULE	=github.com/google/gke-policy-automation/internal/app
 GOFMT_FILES	?=$$(find . -name '*.go' |grep -v vendor)
+COMMIT_SHA  =$(shell g rev-parse --short HEAD)
+LDFLAGS     =-s -w
+
+ifneq (, $(shell git 2>/dev/null))
+	COMMIT_SHA	=$(shell git rev-parse --short HEAD)
+	LDFLAGS		+= -X ${APP_MODULE}.Version=git-${COMMIT_SHA}
+endif
 
 default: clean build test
 
 all: default
 
 build:
-	${GOCMD} build -o ${BINARY}
+	${GOCMD} build -ldflags "${LDFLAGS}" -o ${BINARY}
 
 test: fmtcheck
 	echo $(TEST) | \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,8 +17,7 @@ TEST		?=$$(go list ./... |grep -v 'vendor')
 BINARY		=gke-policy
 APP_MODULE	=github.com/google/gke-policy-automation/internal/app
 GOFMT_FILES	?=$$(find . -name '*.go' |grep -v vendor)
-COMMIT_SHA  =$(shell g rev-parse --short HEAD)
-LDFLAGS     =-s -w
+LDFLAGS		=-s -w
 
 ifneq (, $(shell git 2>/dev/null))
 	COMMIT_SHA	=$(shell git rev-parse --short HEAD)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ clusters against configuration best practices.
 
 [![Build](https://github.com/google/gke-policy-automation/actions/workflows/build.yml/badge.svg)](https://github.com/google/gke-policy-automation/actions/workflows/build.yml)
 [![Policy tests](https://github.com/google/gke-policy-automation/actions/workflows/policy-test.yml/badge.svg)](https://github.com/google/gke-policy-automation/actions/workflows/policy-test.yml)
+[![Version](https://img.shields.io/github/v/release/google/gke-policy-automation?label=version)](https://img.shields.io/github/v/release/google/gke-policy-automation?label=version)
 [![Go Report Card](https://goreportcard.com/badge/github.com/google/gke-policy-automation)](https://goreportcard.com/report/github.com/google/gke-policy-automation)
 [![GoDoc](https://godoc.org/github.com/google/gke-policy-automation?status.svg)](https://godoc.org/github.com/google/gke-policy-automation)
 ![GitHub](https://img.shields.io/github/license/google/gke-policy-automation)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,7 @@ type PolicyAutomation interface {
 	LoadCliConfig(cliConfig *CliConfig) error
 	Close() error
 	ClusterReview() error
+	Version() error
 }
 
 type PolicyAutomationApp struct {
@@ -122,6 +123,11 @@ func (p *PolicyAutomationApp) ClusterReview() error {
 		evalResults = append(evalResults, evalResult)
 	}
 	p.printEvaluationResults(evalResults)
+	return nil
+}
+
+func (p *PolicyAutomationApp) Version() error {
+	p.out.Printf("%s\n", Version)
 	return nil
 }
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -35,6 +35,7 @@ func NewPolicyAutomationCli(p PolicyAutomation) *cli.App {
 		Usage: "Manage GKE policies",
 		Commands: []*cli.Command{
 			CreateClusterCommand(p),
+			CreateVersionCommand(p),
 		},
 	}
 	return app
@@ -90,6 +91,22 @@ func CreateClusterCommand(p PolicyAutomation) *cli.Command {
 					return nil
 				},
 			},
+		},
+	}
+}
+
+func CreateVersionCommand(p PolicyAutomation) *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Shows application version",
+		Action: func(c *cli.Context) error {
+			defer p.Close()
+			if err := p.LoadCliConfig(&CliConfig{}); err != nil {
+				cli.ShowSubcommandHelp(c)
+				return err
+			}
+			p.Version()
+			return nil
 		},
 	}
 }

--- a/internal/app/version.go
+++ b/internal/app/version.go
@@ -1,0 +1,4 @@
+package app
+
+//Application version is set at build-time in the release process
+var Version = "unknown"


### PR DESCRIPTION
Introduced version command. Version is populated with `-X` ldflag.
* for releases, `goreleaser` sets version to the release version
* for local builds, `make` sets version to `git-${SHORT_SHA}` *(if git command is present)*
* otherwise, version is set to `unknown`