### PR TITLE
Small tweaks + introduced tests for few policies migrated from PoC

### DIFF
--- a/gke-policies/policy/control_plane_access.rego
+++ b/gke-policies/policy/control_plane_access.rego
@@ -29,3 +29,13 @@ violation[msg] {
   not input.master_authorized_networks_config.enabled
   msg := "GKE cluster has not enabled master authorized networks configuration" 
 }
+
+violation[msg] {
+  not input.master_authorized_networks_config.cidr_blocks
+  msg := "GKE cluster's master authoreized networks has no CIDR blocks element" 
+}
+
+violation[msg] {
+  count(input.master_authorized_networks_config.cidr_blocks) < 1
+  msg := "GKE cluster's master authoreized networks has no CIDR blocks defined" 
+}

--- a/gke-policies/policy/control_plane_access_test.rego
+++ b/gke-policies/policy/control_plane_access_test.rego
@@ -15,9 +15,29 @@
 package gke.policy.control_plane_access
 
 test_authorized_networks_enabled {
-    valid with input as {"master_authorized_networks_config": {"enabled":true}}
+    valid with input as {"name":"test-cluster","master_authorized_networks_config": {
+        "enabled":true,
+        "cidr_blocks":[
+            {"display_name":"Test Block","cidr_block":"192.168.0.0./16"}
+        ]
+    }}
+}
+
+test_authoized_networks_missing{
+    not valid with input as {"name":"test-cluster"}
 }
 
 test_authorized_networks_disabled{
-    not valid with input as {"master_authorized_networks_config": {"enabled":false}}
+    not valid with input as {"name":"test-cluster","master_authorized_networks_config": {"enabled":false}}
+}
+
+test_authorized_networks_no_cidrs_block{
+    not valid with input as {"name":"test-cluster","master_authorized_networks_config": {"enabled":true}}
+}
+
+test_authorized_networks_empty_cidrs_block{
+    not valid with input as {"name":"test-cluster","master_authorized_networks_config": {
+        "enabled":true,
+        "cidr_blocks":[]
+    }}
 }

--- a/gke-policies/policy/control_plane_endpoint_test.rego
+++ b/gke-policies/policy/control_plane_endpoint_test.rego
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# METADATA
-# title: Control Plane endpoint visibility
-# description: Control Plane endpoint should be locked from external access
-# custom:
-#   group: Security
 package gke.policy.control_plane_endpoint
 
-default valid = false
-
-valid {
-  count(violation) == 0
+test_private_endpoint_enabled {
+    valid with input as {"name": "test-cluster", "private_cluster_config": {"enable_private_endpoint": true}}
 }
 
-violation[msg] {
-  not input.private_cluster_config.enable_private_endpoint
-  msg := "GKE cluster has not enabled private endpoint" 
+test_private_endpoint_disabled {
+    not valid with input as {"name": "test-cluster", "private_cluster_config": {"enable_private_endpoint": false}}
+}
+
+test_private_cluster_config_missing {
+    not valid with input as {"name": "test-cluster"}
 }

--- a/gke-policies/policy/control_plane_redundancy.rego
+++ b/gke-policies/policy/control_plane_redundancy.rego
@@ -26,7 +26,11 @@ valid {
 }
 
 violation[msg] {
-  some location
-  data.gke.rule.location.zonal[location]
-  msg := sprintf("invalid GKE Control plane location %q (not regional)", [location])
+  not input.location
+  msg := "Missing GKE cluster location object"
+}
+
+violation[msg] {
+  not regex.match("^[^-]+-[^-]+$", input.location)
+  msg := sprintf("Invalid GKE Control plane location %q (not regional)", [input.location])
 }

--- a/gke-policies/policy/control_plane_redundancy.rego
+++ b/gke-policies/policy/control_plane_redundancy.rego
@@ -19,6 +19,8 @@
 #   group: Availability
 package gke.policy.control_plane_redundancy
 
+import data.gke.rule.cluster.location.regional
+
 default valid = false
 
 valid {
@@ -31,6 +33,6 @@ violation[msg] {
 }
 
 violation[msg] {
-  not regex.match("^[^-]+-[^-]+$", input.location)
+  not regional(input.location)
   msg := sprintf("Invalid GKE Control plane location %q (not regional)", [input.location])
 }

--- a/gke-policies/policy/control_plane_redundancy_test.rego
+++ b/gke-policies/policy/control_plane_redundancy_test.rego
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# METADATA
-# title: Control Plane endpoint visibility
-# description: Control Plane endpoint should be locked from external access
-# custom:
-#   group: Security
-package gke.policy.control_plane_endpoint
+package gke.policy.control_plane_redundancy
 
-default valid = false
-
-valid {
-  count(violation) == 0
+test_control_plane_regional_location {
+    valid with input as {"name": "test-cluster", "location": "europe-central2"}
 }
 
-violation[msg] {
-  not input.private_cluster_config.enable_private_endpoint
-  msg := "GKE cluster has not enabled private endpoint" 
+test_control_plane_zonal_location {
+    not valid with input as {"name": "test-cluster", "location": "europe-central2-a"}
+}
+
+test_control_plane_missing_location {
+    not valid with input as {"name": "test-cluster"}
 }

--- a/gke-policies/policy/private_cluster_test.rego
+++ b/gke-policies/policy/private_cluster_test.rego
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# METADATA
-# title: Test of invalid policy
-# description: Test of invalid policy
-# custom:
-#   group: Test
-package gke.policy.errored_test_policy
+package gke.policy.private_cluster
 
-valid {
-  count(violation) == 0
+test_private_nodes_enabled {
+    valid with input as {"name": "test-cluster", "private_cluster_config": {"enable_private_nodes": true}}
 }
 
-violation[msg] {
-  msg := "GKE cluster has not enabled private endpoint" 
+test_private_nodes_disabled {
+    not valid with input as {"name": "test-cluster", "private_cluster_config": {"enable_private_nodes": false}}
+}
+
+test_private_cluster_config_missing {
+    not valid with input as {"name": "test-cluster"}
 }

--- a/gke-policies/rule/cluster/location.rego
+++ b/gke-policies/rule/cluster/location.rego
@@ -14,12 +14,10 @@
 
 package gke.rule.cluster.location
 
-regional[location] {
-    location := input.location
-    regex.match("^[^-]+-[^-]+$", location)
+regional(location) {
+  regex.match("^[^-]+-[^-]+$", location)
 }
 
-zonal[location] {
-    location := input.location
+zonal(location) {
     regex.match("^[^-]+-[^-]+-[^-]+$", location)
 }

--- a/gke-policies/rule/cluster/location_test.rego
+++ b/gke-policies/rule/cluster/location_test.rego
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package gke.rule.cluster.location
 
 test_regional {

--- a/gke-policies/rule/cluster/location_test.rego
+++ b/gke-policies/rule/cluster/location_test.rego
@@ -1,0 +1,19 @@
+package gke.rule.cluster.location
+
+test_regional {
+    location := "europe-central2"
+    regional(location)
+    not zonal(location)
+}
+
+test_zonal {
+    location := "europe-central2-a"
+    zonal(location)
+    not regional(location)
+}
+
+test_not_regional_nor_zonal {
+    location := "test"
+    not regional(location)
+    not zonal(location)
+}


### PR DESCRIPTION
Small tweaks + introduced tests for few policies migrated from PoC:
* Choose a private cluster type
* Minimize the cluster control plane exposure
* Authorize access to the control plane
* Use regional control plane

