### PR TITLE
Fixes #27 multiple clusters in config.yaml causes panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.0 (Unreleased)
 
+BUG FIXES:
+
+* Specifying multiple clusters in `config.yaml` causes panic [#27](https://github.com/google/gke-policy-automation/issues/27)
+
 ## 0.0.1 (March 30, 2022)
 
 NOTES:


### PR DESCRIPTION
Policy Agent was wrongly reusing compiled policies to process several evaluation results.
The change introduces evaluation cache that is initialised on every evaluation result processing.