### PR TITLE
Default config values are set after parsing / mapping to config struct

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -59,6 +59,7 @@ func (p *PolicyAutomationApp) LoadCliConfig(cliConfig *CliConfig, validateFn Val
 	} else {
 		config = newConfigFromCli(cliConfig)
 	}
+	setConfigDefaults(config)
 	if validateFn != nil {
 		if err := validateFn(*config); err != nil {
 			return err
@@ -227,14 +228,7 @@ func newConfigFromCli(cliConfig *CliConfig) *Config {
 			Project:  cliConfig.ProjectName,
 		},
 	}
-	if cliConfig.LocalDirectory == "" && cliConfig.GitRepository == "" {
-		log.Debugf("using default git policy source: repo %s, branch %s, directory %s", DefaultGitRepository, DefaultGitBranch, DefaultGitPolicyDir)
-		config.Policies = append(config.Policies, ConfigPolicy{
-			GitRepository: DefaultGitRepository,
-			GitBranch:     DefaultGitBranch,
-			GitDirectory:  DefaultGitPolicyDir,
-		})
-	} else {
+	if cliConfig.LocalDirectory != "" || cliConfig.GitRepository != "" {
 		config.Policies = append(config.Policies, ConfigPolicy{
 			LocalDirectory: cliConfig.LocalDirectory,
 			GitRepository:  cliConfig.GitRepository,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -81,6 +81,32 @@ func TestLoadCliConfig_with_validation(t *testing.T) {
 	}
 }
 
+func TestLoadCliConfig_defaults(t *testing.T) {
+	cliConfig := &CliConfig{
+		CredentialsFile: "./test-fixtures/test_credentials.json",
+		ClusterName:     "test",
+		ClusterLocation: "europe-central2",
+		ProjectName:     "my-project",
+	}
+	pa := PolicyAutomationApp{ctx: context.Background()}
+	err := pa.LoadCliConfig(cliConfig, nil)
+	if err != nil {
+		t.Fatalf("got error; expected nil")
+	}
+	if len(pa.config.Policies) != 1 {
+		t.Fatalf("len of config policies is %d; want %d", len(pa.config.Policies), 1)
+	}
+	policy := pa.config.Policies[0]
+	defaultPolicy := ConfigPolicy{
+		GitRepository: DefaultGitRepository,
+		GitBranch:     DefaultGitBranch,
+		GitDirectory:  DefaultGitPolicyDir,
+	}
+	if !reflect.DeepEqual(policy, defaultPolicy) {
+		t.Error("config policy is not same as default policy")
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	config := &Config{
 		CredentialsFile: "./test-fixtures/test_credentials.json",
@@ -147,42 +173,6 @@ func TestNewConfigFromCli(t *testing.T) {
 	}
 	if policySrc.GitDirectory != input.GitDirectory {
 		t.Errorf("policy gitDirectory = %v; want %v", policySrc.GitDirectory, input.GitDirectory)
-	}
-}
-
-func TestNewConfigFromCli_defaults(t *testing.T) {
-	input := &CliConfig{}
-	config := newConfigFromCli(input)
-	if len(config.Policies) != 1 {
-		t.Fatalf("len(policies) = %v; want %v", len(config.Policies), 1)
-	}
-	policySrc := config.Policies[0]
-	if policySrc.GitRepository != DefaultGitRepository {
-		t.Errorf("policy gitRepository = %v; want %v (default)", policySrc.LocalDirectory, DefaultGitRepository)
-	}
-	if policySrc.GitBranch != DefaultGitBranch {
-		t.Errorf("policy gitBranch = %v; want %v (default)", policySrc.GitBranch, DefaultGitBranch)
-	}
-	if policySrc.GitDirectory != DefaultGitPolicyDir {
-		t.Errorf("policy gitDirectory = %v; want %v (default)", policySrc.GitDirectory, DefaultGitPolicyDir)
-	}
-}
-
-func TestNewConfigFromCli_defaultPolicySrc(t *testing.T) {
-	input := &CliConfig{}
-	config := newConfigFromCli(input)
-	if len(config.Policies) != 1 {
-		t.Fatalf("len(policies) = %v; want %v", len(config.Policies), 1)
-	}
-	policySrc := config.Policies[0]
-	if policySrc.GitRepository != DefaultGitRepository {
-		t.Errorf("policy gitRepository = %v; want %v", policySrc.GitRepository, DefaultGitRepository)
-	}
-	if policySrc.GitBranch != DefaultGitBranch {
-		t.Errorf("policy gitBranch = %v; want %v", policySrc.GitBranch, DefaultGitBranch)
-	}
-	if policySrc.GitDirectory != DefaultGitPolicyDir {
-		t.Errorf("policy gitDirectory = %v; want %v", policySrc.GitDirectory, DefaultGitPolicyDir)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -95,7 +95,7 @@ func TestLoadCliConfig_defaults(t *testing.T) {
 	pa := PolicyAutomationApp{ctx: context.Background()}
 	err := pa.LoadCliConfig(cliConfig, nil)
 	if err != nil {
-		t.Fatalf("got error; expected nil")
+		t.Fatalf("err is not nil; want nil; err = %s", err)
 	}
 	if len(pa.config.Policies) != 1 {
 		t.Fatalf("len of config policies is %d; want %d", len(pa.config.Policies), 1)

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -174,3 +174,21 @@ func TestValidatePolicyCheckConfig_negative(t *testing.T) {
 		}
 	}
 }
+
+func TestSetConfigDefaults_policySrc(t *testing.T) {
+	config := Config{}
+	setConfigDefaults(&config)
+	if len(config.Policies) < 1 {
+		t.Fatalf("len of policy sources is %d; want %d", len(config.Policies), 1)
+	}
+	policySrc := config.Policies[0]
+	if policySrc.GitRepository != DefaultGitRepository {
+		t.Errorf("policy gitRepository = %v; want %v", policySrc.GitRepository, DefaultGitRepository)
+	}
+	if policySrc.GitBranch != DefaultGitBranch {
+		t.Errorf("policy gitBranch = %v; want %v", policySrc.GitBranch, DefaultGitBranch)
+	}
+	if policySrc.GitDirectory != DefaultGitPolicyDir {
+		t.Errorf("policy gitDirectory = %v; want %v", policySrc.GitDirectory, DefaultGitPolicyDir)
+	}
+}


### PR DESCRIPTION
So far default config values *(policy source's default GIT repo params)* were set only when CLI flags were passed.
It was not possible to use `config.yaml` with default policy source assumed.

This PR changes this behaviour so defaults are now applied in a consistent way - i.e. it will be possible to use `config.yaml` without any policy sources defined. In a such case, the the tool will use default repo.