### PR TITLE
forbid using default service account for GKE nodes

### DIFF
--- a/gke-policies/policy/node_pool_forbid_default_sa.rego
+++ b/gke-policies/policy/node_pool_forbid_default_sa.rego
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# METADATA
+# title: Forbid default compute SA on node_pool
+# description: GKE node pools should have a dedicated sa with a restricted set of permissions
+# custom:
+#   group: Security
+package gke.policy.node_pool_forbid_default_sa
+
+default valid = false
+
+valid {
+	count(violation) == 0
+}
+
+violation[msg] {
+	input.node_pools[pool].config.service_account == "default"
+	msg := sprintf("GKE cluster node_pool %q should have a dedicated SA", [input.node_pools[pool].name])
+}

--- a/gke-policies/policy/node_pool_forbid_default_sa_test.rego
+++ b/gke-policies/policy/node_pool_forbid_default_sa_test.rego
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# METADATA
+# title: Forbid default compute SA on node_pool
+# description: GKE node pools should have a dedicated sa with a restricted set of permissions
+# custom:
+#   group: Security
+
+package gke.policy.node_pool_forbid_default_sa
+
+test_cluster_with_2_np_and_mixed_sas {
+	not valid with input as {"name": "cluster-1", "legacy_abac": {"enabled": false}, "node_pools": [{"name": "default", "config": {"machine_type": "e2-standard-4", "disk_size_gb": 100, "service_account": "default", "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}, "management": {"auto_repair": true, "auto_upgrade": true}}, {"name": "pool-1", "config": {"machine_type": "e2-standard-2", "disk_size_gb": 100, "oauth_scopes": ["https://www.googleapis.com/auth/cloud-platform"], "service_account": "gke-sa@prj.iam.gserviceaccount.com", "metadata": {"disable-legacy-endpoints": "true"}, "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}}]}
+}
+
+test_cluster_with_2_np_and_dedicated_sas {
+	valid with input as {"name": "cluster-1", "legacy_abac": {"enabled": false}, "node_pools": [{"name": "default", "config": {"machine_type": "e2-standard-4", "disk_size_gb": 100, "service_account": "gke-sa@prj.iam.gserviceaccount.com", "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}, "management": {"auto_repair": true, "auto_upgrade": true}}, {"name": "pool-1", "config": {"machine_type": "e2-standard-2", "disk_size_gb": 100, "oauth_scopes": ["https://www.googleapis.com/auth/cloud-platform"], "service_account": "gke-sa@prj.iam.gserviceaccount.com", "metadata": {"disable-legacy-endpoints": "true"}, "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}}]}
+}
+
+test_cluster_with_1_np_and_default_sa {
+	not valid with input as {"name": "cluster-1", "legacy_abac": {"enabled": false}, "node_pools": [{"name": "default", "config": {"machine_type": "e2-standard-4", "disk_size_gb": 100, "service_account": "default", "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}, "management": {"auto_repair": true, "auto_upgrade": true}}]}
+}
+
+test_cluster_with_1_np_and_dedicated_sa {
+	valid with input as {"name": "cluster-1", "legacy_abac": {"enabled": false}, "node_pools": [{"name": "pool-1", "config": {"machine_type": "e2-standard-4", "disk_size_gb": 100, "service_account": "gke-sa@prj.iam.gserviceaccount.com", "image_type": "COS_CONTAINERD", "disk_type": "pd-standard", "workload_metadata_config": {"mode": 2}, "shielded_instance_config": {"enable_integrity_monitoring": true}}, "management": {"auto_repair": true, "auto_upgrade": true}}]}
+}


### PR DESCRIPTION
Create policy that checks if cluster is using default compute service account on a nodes.