### PR TITLE
Cluster discovery skipped zonal clusters due to name parttern mismatch

### DIFF
--- a/internal/gke/discovery.go
+++ b/internal/gke/discovery.go
@@ -152,7 +152,7 @@ func filterMapSeachResults(results []*assetpb.ResourceSearchResult) []string {
 		}
 		id, err := getIDFromName(result.Name)
 		if err != nil {
-			log.Warnf("skipping cluster asset search result due to ivalid name: %s", err)
+			log.Warnf("skipping cluster asset search result due to invalid name: %s", err)
 			continue
 		}
 		identifiers = append(identifiers, id)
@@ -162,12 +162,12 @@ func filterMapSeachResults(results []*assetpb.ResourceSearchResult) []string {
 
 //getIDFromName returns cluster identifier from full cluster asset name.
 func getIDFromName(name string) (string, error) {
-	r := regexp.MustCompile(`//container\.googleapis\.com/(projects/.+/locations/.+/clusters/.+)`)
+	r := regexp.MustCompile(`//container\.googleapis\.com/(projects/.+/(locations|zones)/.+/clusters/.+)`)
 	if !r.MatchString(name) {
-		return "", fmt.Errorf("given name does not match GKE cluster name pattern")
+		return "", fmt.Errorf("given name %q does not match GKE cluster name pattern", name)
 	}
 	matches := r.FindStringSubmatch(name)
-	if len(matches) != 2 {
+	if len(matches) != 3 {
 		return "", fmt.Errorf("invalid number of regexp matches")
 	}
 	return matches[1], nil

--- a/internal/gke/discovery_test.go
+++ b/internal/gke/discovery_test.go
@@ -180,14 +180,18 @@ func TestFilterMapSeachResults(t *testing.T) {
 }
 
 func TestGetIDFromName(t *testing.T) {
-	id := "projects/my-project/locations/europe-west2/clusters/my-cluster"
-	name := fmt.Sprintf("//container.googleapis.com/%s", id)
-	result, err := getIDFromName(name)
-	if err != nil {
-		t.Fatalf("err is not nil; want nil; err = %s", err)
+	ids := []string{
+		"projects/my-project/locations/europe-west2/clusters/my-cluster",
+		"projects/my-project/zones/europe-west2-b/clusters/other-cluster",
 	}
-	if result != id {
-		t.Errorf("result is %s; want %s", result, id)
+	for i := range ids {
+		result, err := getIDFromName(fmt.Sprintf("//container.googleapis.com/%s", ids[i]))
+		if err != nil {
+			t.Fatalf("err is not nil; want nil; err = %s", err)
+		}
+		if result != ids[i] {
+			t.Errorf("result is %s; want %s", result, ids[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Fixed bug in a cluster discovery mechanism that skipped zonal clusters (due to cluster name mismatch)