### PR TITLE
Trigger cluster discover on a project from CLI

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -437,19 +437,23 @@ func newConfigFromCli(cliConfig *CliConfig) *cfg.Config {
 	config.K8SCheck = cliConfig.K8SCheck
 	config.CredentialsFile = cliConfig.CredentialsFile
 	config.DumpFile = cliConfig.DumpFile
-	if cliConfig.ClusterName != "" || cliConfig.ClusterLocation != "" || cliConfig.ProjectName != "" {
-		config.Clusters = []cfg.ConfigCluster{
-			{
-				Name:     cliConfig.ClusterName,
-				Location: cliConfig.ClusterLocation,
-				Project:  cliConfig.ProjectName,
-			},
+	if cliConfig.DiscoveryEnabled {
+		config.ClusterDiscovery.Enabled = true
+		config.ClusterDiscovery.Projects = []string{cliConfig.ProjectName}
+	} else {
+		if cliConfig.ClusterName != "" || cliConfig.ClusterLocation != "" || cliConfig.ProjectName != "" {
+			config.Clusters = []cfg.ConfigCluster{
+				{
+					Name:     cliConfig.ClusterName,
+					Location: cliConfig.ClusterLocation,
+					Project:  cliConfig.ProjectName,
+				},
+			}
 		}
 	}
 	config.Outputs = append(config.Outputs, cfg.ConfigOutput{
 		FileName: cliConfig.OutputFile,
 	})
-
 	if cliConfig.LocalDirectory != "" || cliConfig.GitRepository != "" {
 		config.Policies = append(config.Policies, cfg.ConfigPolicy{
 			LocalDirectory: cliConfig.LocalDirectory,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -439,7 +439,9 @@ func newConfigFromCli(cliConfig *CliConfig) *cfg.Config {
 	config.DumpFile = cliConfig.DumpFile
 	if cliConfig.DiscoveryEnabled {
 		config.ClusterDiscovery.Enabled = true
-		config.ClusterDiscovery.Projects = []string{cliConfig.ProjectName}
+		if cliConfig.ProjectName != "" {
+			config.ClusterDiscovery.Projects = []string{cliConfig.ProjectName}
+		}
 	} else {
 		if cliConfig.ClusterName != "" || cliConfig.ClusterLocation != "" || cliConfig.ProjectName != "" {
 			config.Clusters = []cfg.ConfigCluster{

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -20,19 +20,20 @@ import (
 )
 
 type CliConfig struct {
-	ConfigFile      string
-	SilentMode      bool
-	K8SCheck        bool
-	CredentialsFile string
-	DumpFile        string
-	ClusterName     string
-	ClusterLocation string
-	ProjectName     string
-	GitRepository   string
-	GitBranch       string
-	GitDirectory    string
-	LocalDirectory  string
-	OutputFile      string
+	ConfigFile       string
+	SilentMode       bool
+	K8SCheck         bool
+	CredentialsFile  string
+	DumpFile         string
+	ClusterName      string
+	ClusterLocation  string
+	ProjectName      string
+	GitRepository    string
+	GitBranch        string
+	GitDirectory     string
+	LocalDirectory   string
+	OutputFile       string
+	DiscoveryEnabled bool
 }
 
 func NewPolicyAutomationCli(p PolicyAutomation) *cli.App {
@@ -169,6 +170,11 @@ func getCommonFlags(config *CliConfig) []cli.Flag {
 
 func getClusterSourceFlags(config *CliConfig) []cli.Flag {
 	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "discovery",
+			Usage:       "Enables cluster discovery on a given project",
+			Destination: &config.DiscoveryEnabled,
+		},
 		&cli.StringFlag{
 			Name:        "dump",
 			Aliases:     []string{"d"},


### PR DESCRIPTION
Added `--discovery` flag to CLI to trigger cluster discovery mechanism even without config.
This will work on a project level when supplemented with a `-p <projectID>` flag.