### PR TITLE
logs from logger can be stored in a files and in JSON format

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -33,42 +33,95 @@ const (
 var log = NewLogger()
 
 type envProvider interface {
-	Getenv(key string) string
+	LookupEnv(key string) (string, bool)
 }
 
-type OsEnvProvider struct{}
+type fileProvider interface {
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+}
 
-func (p OsEnvProvider) Getenv(key string) string {
-	return os.Getenv(key)
+type osEnvProvider struct{}
+
+func (p osEnvProvider) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+type osFileProvider struct{}
+
+func (p osFileProvider) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
 }
 
 func NewLogger() *logrus.Logger {
-	envProvider := OsEnvProvider{}
+	envProvider := osEnvProvider{}
+	fileProvider := osFileProvider{}
 	logger := logrus.New()
-	level, err := getLogLevel(envProvider)
-	if err != nil {
-		logger.SetOutput(io.Discard)
-	}
+	output, level := getLogOutputLevel(envProvider, fileProvider)
 	logger.SetLevel(level)
+	logger.SetOutput(output)
+	logger.SetFormatter(getLogFormatter(envProvider))
 	return logger
 }
 
-func getLogLevel(p envProvider) (logrus.Level, error) {
-	switch value := p.Getenv(levelVarName); strings.ToLower(value) {
-	case "trace":
-		return logrus.TraceLevel, nil
-	case "debug":
-		return logrus.DebugLevel, nil
-	case "info":
-		return logrus.InfoLevel, nil
-	case "warn":
-		return logrus.WarnLevel, nil
-	case "error":
-		return logrus.ErrorLevel, nil
-	case "fatal":
-		return logrus.FatalLevel, nil
+func getLogOutputLevel(e envProvider, f fileProvider) (io.Writer, logrus.Level) {
+	lvl, err := getLogLevel(e)
+	if err != nil {
+		return io.Discard, lvl
 	}
-	return defaultLogLevel, fmt.Errorf("unsupported or missing log level")
+	return getLogOutput(e, f), lvl
+}
+
+func getLogLevel(e envProvider) (logrus.Level, error) {
+	value, ok := e.LookupEnv(levelVarName)
+	if !ok {
+		return defaultLogLevel, fmt.Errorf("env variable %q not set", levelVarName)
+	}
+	var level logrus.Level
+	switch strings.ToLower(value) {
+	case "trace":
+		level = logrus.TraceLevel
+	case "debug":
+		level = logrus.DebugLevel
+	case "info":
+		level = logrus.InfoLevel
+	case "warn":
+		level = logrus.WarnLevel
+	case "error":
+		level = logrus.ErrorLevel
+	case "fatal":
+		level = logrus.FatalLevel
+	default:
+		fmt.Printf("unknown log level %q, using defaults", value)
+		level = defaultLogLevel
+	}
+	return level, nil
+}
+
+func getLogOutput(e envProvider, f fileProvider) io.Writer {
+	logFilePath, ok := e.LookupEnv(pathVarName)
+	if !ok {
+		return os.Stderr
+	}
+	file, err := f.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		fmt.Printf("couldn't open log file %q, using default log output; %s\n", logFilePath, err)
+		return os.Stderr
+	}
+	return file
+}
+
+func getLogFormatter(e envProvider) logrus.Formatter {
+	switch value, _ := e.LookupEnv(formatVarName); strings.ToLower(value) {
+	case "json":
+		return &logrus.JSONFormatter{
+			FieldMap: logrus.FieldMap{
+				logrus.FieldKeyLevel: "severity",
+				logrus.FieldKeyMsg:   "message",
+			},
+		}
+	default:
+		return &logrus.TextFormatter{}
+	}
 }
 
 func Debugf(format string, args ...interface{}) {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -15,17 +15,28 @@
 package log
 
 import (
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockEnvProvider struct {
-	GetenvFn func(string) string
+	LookupEnvFn func(key string) (string, bool)
 }
 
-func (m MockEnvProvider) Getenv(s string) string {
-	return m.GetenvFn(s)
+func (m MockEnvProvider) LookupEnv(key string) (string, bool) {
+	return m.LookupEnvFn(key)
+}
+
+type MockFileProvider struct {
+	OpenFileFn func(name string, flag int, perm os.FileMode) (*os.File, error)
+}
+
+func (m MockFileProvider) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return m.OpenFileFn(name, flag, perm)
 }
 
 func TestGetLogLevel(t *testing.T) {
@@ -40,11 +51,11 @@ func TestGetLogLevel(t *testing.T) {
 	}
 	for k, v := range mappings {
 		m := MockEnvProvider{
-			GetenvFn: func(s string) string {
-				if s != levelVarName {
-					t.Fatalf("env variable = %v; want %v", s, levelVarName)
+			LookupEnvFn: func(key string) (string, bool) {
+				if key != levelVarName {
+					t.Fatalf("env variable = %v; want %v", key, levelVarName)
 				}
-				return k
+				return k, true
 			},
 		}
 		level, _ := getLogLevel(m)
@@ -52,4 +63,79 @@ func TestGetLogLevel(t *testing.T) {
 			t.Errorf("value = %v, level = %v; want %v", k, level, v)
 		}
 	}
+}
+
+func TestGetLogLevelVarNotSet(t *testing.T) {
+	m := MockEnvProvider{
+		LookupEnvFn: func(key string) (string, bool) {
+			return "", false
+		},
+	}
+	_, err := getLogLevel(m)
+	if err == nil {
+		t.Errorf("err = nil, want error")
+	}
+}
+
+func TestGetLogOutput(t *testing.T) {
+	path := "/some/test/file"
+	file := &os.File{}
+	e := MockEnvProvider{
+		LookupEnvFn: func(key string) (string, bool) {
+			if key != pathVarName {
+				t.Fatalf("env variable = %v; want %v", key, pathVarName)
+			}
+			return path, true
+		},
+	}
+	f := MockFileProvider{
+		OpenFileFn: func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			return file, nil
+		},
+	}
+	output := getLogOutput(e, f)
+	if !reflect.DeepEqual(output, file) {
+		t.Fatalf("output file = %+v; want %+v", output, file)
+	}
+}
+
+func TestGetLogOutputVarNotSet(t *testing.T) {
+	file := os.Stderr
+	e := MockEnvProvider{
+		LookupEnvFn: func(key string) (string, bool) {
+			return "", false
+		},
+	}
+	f := MockFileProvider{
+		OpenFileFn: func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			return file, nil
+		},
+	}
+	output := getLogOutput(e, f)
+	if !reflect.DeepEqual(output, file) {
+		t.Fatalf("output file = %+v; want %+v", output, file)
+	}
+}
+
+func TestGetLogFormatter(t *testing.T) {
+	e := MockEnvProvider{
+		LookupEnvFn: func(key string) (string, bool) {
+			if key != formatVarName {
+				t.Fatalf("env variable = %v; want %v", key, formatVarName)
+			}
+			return "json", true
+		},
+	}
+	formatter := getLogFormatter(e)
+	assert.IsType(t, &logrus.JSONFormatter{}, formatter)
+}
+
+func TestGetLogFormatterVarNotSet(t *testing.T) {
+	e := MockEnvProvider{
+		LookupEnvFn: func(key string) (string, bool) {
+			return "", false
+		},
+	}
+	formatter := getLogFormatter(e)
+	assert.IsType(t, &logrus.TextFormatter{}, formatter)
 }


### PR DESCRIPTION
* setting env variable`GKE_POLICY_LOG_PATH=log.log` will cause logs to be stored in `log.log`
* setting env variable`GKE_POLICY_LOG_FORMAT=JSON` will cause logs to be formatted as JSON <-- useful for Cloud Logging