### PR TITLE
Added check for empty clusters in a cluster review func

### DIFF
--- a/internal/app/app_check_clusters.go
+++ b/internal/app/app_check_clusters.go
@@ -121,9 +121,9 @@ func (p *PolicyAutomationApp) evaluateClusters(regoPackageBases []string) error 
 		return err
 	}
 	if len(clusterIds) < 1 {
-		p.out.ColorPrintf("%s [yellow][bold]No clusters to check, finishing...\n", outputs.ICON_INFO)
+		p.out.ColorPrintf("%s [yellow][bold]No clusters to check, finishing...\n", outputs.IconInfo)
 		log.Info("Cluster review finished")
-		p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.ICON_INFO)
+		p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.IconInfo)
 		return nil
 	}
 	p.out.ColorPrintf("%s [light_gray][bold]Fetching data from %d input(s) for %d cluster(s)\n",
@@ -170,7 +170,7 @@ func (p *PolicyAutomationApp) evaluateClusters(regoPackageBases []string) error 
 		log.Infof("Collector %s processing closed", c.Name())
 	}
 	log.Info("Cluster review finished")
-	p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.ICON_INFO)
+	p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.IconInfo)
 	return nil
 }
 

--- a/internal/app/app_check_clusters.go
+++ b/internal/app/app_check_clusters.go
@@ -120,6 +120,12 @@ func (p *PolicyAutomationApp) evaluateClusters(regoPackageBases []string) error 
 		log.Errorf("could not identify clusters: %s", err)
 		return err
 	}
+	if len(clusterIds) < 1 {
+		p.out.ColorPrintf("%s [yellow][bold]No clusters to check, finishing...\n", outputs.ICON_INFO)
+		log.Info("Cluster review finished")
+		p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.ICON_INFO)
+		return nil
+	}
 	p.out.ColorPrintf("%s [light_gray][bold]Fetching data from %d input(s) for %d cluster(s)\n",
 		outputs.ICON_INFO, len(p.inputs), len(clusterIds))
 	clusterData, errors := inputs.GetAllInputsData(p.inputs, clusterIds)
@@ -164,7 +170,7 @@ func (p *PolicyAutomationApp) evaluateClusters(regoPackageBases []string) error 
 		log.Infof("Collector %s processing closed", c.Name())
 	}
 	log.Info("Cluster review finished")
-	p.out.ColorPrintf("\u2139 [light_gray][bold]Cluster review finished\n")
+	p.out.ColorPrintf("%s [light_gray][bold]Cluster review finished\n", outputs.ICON_INFO)
 	return nil
 }
 


### PR DESCRIPTION
In case when no clusters are discovered, GPA tool is continuing the flow of reviewing the empty set of clusters. 
This produces unnecessary info messages on the terminal.  The tool should fail fast and finish its operation when no clusters were detected.