### PR TITLE
Support for vector metrics + more wildcards in the queries

### DIFF
--- a/internal/gke/discovery.go
+++ b/internal/gke/discovery.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gke implements Google Kubernetes Engine specific features like cluster discovery
 package gke
 
 import (

--- a/internal/gke/discovery_local.go
+++ b/internal/gke/discovery_local.go
@@ -17,9 +17,11 @@ package gke
 import (
 	"encoding/json"
 	"os"
-
-	"github.com/google/gke-policy-automation/internal/inputs"
 )
+
+type localCluster struct {
+	Name string `json:"name"`
+}
 
 type localDiscoveryClient struct {
 	readFileFunc func(name string) ([]byte, error)
@@ -56,7 +58,7 @@ func (c *localDiscoveryClient) getClusters() ([]string, error) {
 		return nil, err
 	}
 
-	var clusters []*inputs.Cluster
+	var clusters []*localCluster
 	if err = json.Unmarshal(data, &clusters); err != nil {
 		return nil, err
 	}

--- a/internal/gke/gke.go
+++ b/internal/gke/gke.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gke implements Google Kubernetes Engine specific features like cluster discovery
+package gke
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func GetClusterID(project string, location string, name string) string {
+	return fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
+}
+
+func SliceAndValidateClusterID(id string) (string, string, string, error) {
+	r := regexp.MustCompile(`projects/(.+)/(locations|zones)/(.+)/clusters/(.+)`)
+	if !r.MatchString(id) {
+		return "", "", "", fmt.Errorf("input %q does not match regexp", id)
+	}
+	matches := r.FindStringSubmatch(id)
+	if len(matches) != 5 {
+		return "", "", "", fmt.Errorf("wrong number of matches, got %d, expected %d", len(matches), 5)
+	}
+	return matches[1], matches[3], matches[4], nil
+}

--- a/internal/gke/gke_test.go
+++ b/internal/gke/gke_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gke
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func TestGetClusterID(t *testing.T) {
+	projectID := "test-project"
+	clusterLocation := "europe-central2"
+	clusterName := "warsaw"
+	name := GetClusterID(projectID, clusterLocation, clusterName)
+	re := regexp.MustCompile(`^projects/([^/]+)/locations/([^/]+)/clusters/([^/]+)$`)
+	if !re.MatchString(name) {
+		t.Fatalf("name: %q, does not match regexp: %q", name, re.String())
+	}
+	matches := re.FindStringSubmatch(name)
+	if matches[1] != projectID {
+		t.Errorf("match[1] = %v; want %v", matches[1], projectID)
+	}
+	if matches[2] != clusterLocation {
+		t.Errorf("match[2] = %v; want %v", matches[2], clusterLocation)
+	}
+	if matches[3] != clusterName {
+		t.Errorf("match[3] = %v; want %v", matches[3], clusterName)
+	}
+}
+
+func TestSliceAndValidateClusterID(t *testing.T) {
+	projectID := "demo-project-123"
+	clusterLocation := "europe-central2"
+	clusterName := "cluster-waw"
+	input := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", projectID, clusterLocation, clusterName)
+
+	resultProjectID, resultClusterLocation, resultClusterName, err := SliceAndValidateClusterID(input)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	if resultProjectID != projectID {
+		t.Errorf("projectID = %v; want %v", resultProjectID, projectID)
+	}
+	if resultClusterLocation != clusterLocation {
+		t.Errorf("clusterLocation = %v; want %v", resultProjectID, clusterLocation)
+	}
+	if resultClusterName != clusterName {
+		t.Errorf("clusterName = %v; want %v", resultProjectID, clusterName)
+	}
+}
+
+func TestSliceAndValidateClusterID_negative(t *testing.T) {
+	input := ("projects/demo-project-123/regions/europe-central2/clusters/cluster-waw")
+	_, _, _, err := SliceAndValidateClusterID(input)
+	if err == nil {
+		t.Fatalf("err = nil; want err")
+	}
+}

--- a/internal/inputs/clients/metrics.go
+++ b/internal/inputs/clients/metrics.go
@@ -16,10 +16,14 @@ package clients
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
 
+	"github.com/google/gke-policy-automation/internal/gke"
 	"github.com/google/gke-policy-automation/internal/log"
 
 	"github.com/prometheus/client_golang/api"
@@ -28,19 +32,27 @@ import (
 	pmodel "github.com/prometheus/common/model"
 )
 
+const (
+	MetricQueryWildcardClusterID       = `\$CLUSTER_ID`
+	MetricQueryWildcardClusterName     = `\$CLUSTER_NAME`
+	MetricQueryWildcardClusterLocation = `\$CLUSTER_LOCATION`
+	MetricQueryWildcardClusterProject  = `\$CLUSTER_PROJECT`
+)
+
 type MetricQuery struct {
 	Name  string
 	Query string
 }
 
 type Metric struct {
-	Name  string
-	Value string
+	Name        string                 `json:"name"`
+	ScalarValue float64                `json:"scalar"`
+	VectorValue map[string]interface{} `json:"vector"`
 }
 
 type MetricsClient interface {
-	GetMetric(query MetricQuery, clusterName string) (string, error)
-	GetMetricsForCluster(queries []MetricQuery, clusterName string) (map[string]Metric, error)
+	GetMetric(query MetricQuery, clusterID string) (*Metric, error)
+	GetMetricsForCluster(queries []MetricQuery, clusterID string) (map[string]Metric, error)
 }
 
 type metricsClient struct {
@@ -51,7 +63,6 @@ type metricsClient struct {
 }
 
 func newMetricsClient(ctx context.Context, projectID string, authToken string, maxGoroutines int) (MetricsClient, error) {
-
 	// Creates a client.
 	client, err := api.NewClient(api.Config{
 		Address:      "https://monitoring.googleapis.com/v1/projects/" + projectID + "/location/global/prometheus/",
@@ -109,54 +120,55 @@ func (b *metricsClientBuilder) Build() (MetricsClient, error) {
 	metricsClient, err := newMetricsClient(b.ctx, b.projectID, b.authToken, maxGoRoutines)
 
 	if err != nil {
-		log.Fatalf("Failed to create metrics client: %v", err)
+		log.Fatalf("failed to create metrics client: %v", err)
 		return nil, err
 	}
 	return metricsClient, nil
 }
 
-func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterName string) (string, error) {
-
-	query := metricQuery.Query
-
-	query = replaceWildcard("CLUSTER_NAME", clusterName, query)
-
-	log.Debugf("Querying metric client with query: " + query)
+func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterID string) (*Metric, error) {
+	query := replaceAllWildcards(clusterID, metricQuery.Query)
+	log.Debugf("querying metric client with a query: %s", query)
 
 	result, warnings, err := m.api.Query(m.ctx, query, time.Now())
 	if err != nil {
-		log.Fatalf("Failed to query metrics client: %v", err)
-		return "", err
+		log.Fatalf("failed to query metrics client: %v", err)
+		return nil, err
 	}
 	if warnings != nil {
-		log.Warnf("Warning when querying metrics client: %v", warnings)
+		log.Warnf("warning when querying metrics client: %v", warnings)
 	}
-
-	queryResults := make([]string, 0, 1)
 
 	data, ok := result.(pmodel.Vector)
 	if !ok {
-		log.Fatalf("Unsupported result format: %s", result.Type().String())
-		return "", err
-	}
-	for _, v := range data {
-		queryResults = append(queryResults, v.Value.String())
+		badType := reflect.TypeOf(result)
+		log.Fatalf("unsupported result format: %s", badType)
+		return nil, fmt.Errorf("unsupported result format: %s", badType)
 	}
 
-	ret := ""
-	if len(queryResults) > 0 {
-		ret = queryResults[0]
-		if len(queryResults) > 1 {
-			log.Warnf("query %s returned more than one result for cluster %s", query, clusterName)
-		}
-	} else {
-		log.Warnf("query %s returned no value found for cluster %s", query, clusterName)
+	if len(data) < 1 {
+		return nil, fmt.Errorf("empty result vector")
 	}
 
-	return ret, nil
+	if data.Len() == 1 {
+		dataSample := data[0]
+		return &Metric{
+			Name:        metricQuery.Name,
+			ScalarValue: float64(dataSample.Value),
+		}, nil
+	}
+	vectorValue := make(map[string]interface{})
+	for _, dataSample := range data {
+		metricValues := valuesFromMetric(dataSample.Metric)
+		populateVectorMap(vectorValue, metricValues, float64(dataSample.Value))
+	}
+	return &Metric{
+		Name:        metricQuery.Name,
+		VectorValue: vectorValue,
+	}, nil
 }
 
-func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterName string) (map[string]Metric, error) {
+func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterID string) (map[string]Metric, error) {
 
 	metricsResult := make(map[string]Metric)
 
@@ -169,7 +181,7 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterName 
 		close(queryChannel)
 	}()
 
-	resultsChannel := make(chan Metric, m.maxGoRoutines)
+	resultsChannel := make(chan *Metric, m.maxGoRoutines)
 	errorChannel := make(chan error, m.maxGoRoutines)
 
 	go func() {
@@ -180,18 +192,14 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterName 
 			log.Debugf("Starting getMetrics goroutine")
 			go func() {
 				for q := range queryChannel {
-					log.Debugf("GetMetric for %s, cluster %s", q, clusterName)
-					r, err := m.GetMetric(q, clusterName)
+					log.Debugf("GetMetric for %s, cluster %s", q, clusterID)
+					metric, err := m.GetMetric(q, clusterID)
 					if err != nil {
 						log.Debugf("unable to get metric: %s", err)
 						errorChannel <- err
 						wg.Done()
 					}
-					metricResult := Metric{
-						Name:  q.Name,
-						Value: r,
-					}
-					resultsChannel <- metricResult
+					resultsChannel <- metric
 				}
 				wg.Done()
 			}()
@@ -208,7 +216,7 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterName 
 		return nil, err
 	}
 	for result := range resultsChannel {
-		metricsResult[result.Name] = result
+		metricsResult[result.Name] = *result
 	}
 	return metricsResult, nil
 }
@@ -217,4 +225,43 @@ func replaceWildcard(wildcard string, value string, query string) string {
 	clusterNameExp := regexp.MustCompile(wildcard)
 
 	return clusterNameExp.ReplaceAllString(query, "\""+value+"\"")
+}
+
+func replaceAllWildcards(clusterID string, query string) string {
+	result := replaceWildcard(MetricQueryWildcardClusterID, clusterID, query)
+	if clusterProjectID, clusterLocation, clusterName, err := gke.SliceAndValidateClusterID(clusterID); err == nil {
+		result = replaceWildcard(MetricQueryWildcardClusterProject, clusterProjectID, result)
+		result = replaceWildcard(MetricQueryWildcardClusterLocation, clusterLocation, result)
+		result = replaceWildcard(MetricQueryWildcardClusterName, clusterName, result)
+	} else {
+		log.Warnf("failed to replace some wildcards due to project identifier validation: %s", err)
+	}
+	return result
+}
+
+func valuesFromMetric(metric pmodel.Metric) []string {
+	result := make([]string, 0, len(metric))
+	keys := make([]string, 0, len(metric))
+	for key := range metric {
+		keys = append(keys, string(key))
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		result = append(result, string(metric[pmodel.LabelName(key)]))
+	}
+	return result
+}
+
+func populateVectorMap(m map[string]interface{}, labels []string, value float64) {
+	if len(labels) == 1 {
+		m[labels[0]] = value
+		return
+	}
+	label := labels[0]
+	mValue, ok := m[label]
+	if !ok {
+		mValue = make(map[string]interface{})
+		m[label] = mValue
+	}
+	populateVectorMap(mValue.(map[string]interface{}), labels[1:], value)
 }

--- a/internal/inputs/gke.go
+++ b/internal/inputs/gke.go
@@ -16,7 +16,6 @@ package inputs
 
 import (
 	"context"
-	"fmt"
 
 	container "cloud.google.com/go/container/apiv1"
 	"cloud.google.com/go/container/apiv1/containerpb"
@@ -91,8 +90,4 @@ func (i *gkeAPIInput) Close() error {
 		return i.client.Close()
 	}
 	return nil
-}
-
-func GetClusterName(project string, location string, name string) string {
-	return fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, name)
 }

--- a/internal/inputs/gke_test.go
+++ b/internal/inputs/gke_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/google/gke-policy-automation/internal/gke"
 	gax "github.com/googleapis/gax-go/v2"
 )
 
@@ -82,7 +83,7 @@ func TestGetCluster(t *testing.T) {
 	projectID := "test-project"
 	clusterLocation := "europe-central2"
 	clusterName := "warsaw"
-	data, err := input.GetData(GetClusterName(projectID, clusterLocation, clusterName))
+	data, err := input.GetData(gke.GetClusterID(projectID, clusterLocation, clusterName))
 	if err != nil {
 		t.Fatalf("error when fetching cluster: %v", err)
 	}
@@ -105,26 +106,5 @@ func TestClose(t *testing.T) {
 	err := input.Close()
 	if err == nil {
 		t.Errorf("gkeAPIInput close() error is nil; want mocked error")
-	}
-}
-
-func TestGetClusterName(t *testing.T) {
-	projectID := "test-project"
-	clusterLocation := "europe-central2"
-	clusterName := "warsaw"
-	name := GetClusterName(projectID, clusterLocation, clusterName)
-	re := regexp.MustCompile(`^projects/([^/]+)/locations/([^/]+)/clusters/([^/]+)$`)
-	if !re.MatchString(name) {
-		t.Fatalf("name: %q, does not match regexp: %q", name, re.String())
-	}
-	matches := re.FindStringSubmatch(name)
-	if matches[1] != projectID {
-		t.Errorf("match[1] = %v; want %v", matches[1], projectID)
-	}
-	if matches[2] != clusterLocation {
-		t.Errorf("match[2] = %v; want %v", matches[2], clusterLocation)
-	}
-	if matches[3] != clusterName {
-		t.Errorf("match[3] = %v; want %v", matches[3], clusterName)
 	}
 }

--- a/internal/inputs/metric_input_test.go
+++ b/internal/inputs/metric_input_test.go
@@ -25,20 +25,20 @@ import (
 type metricsClientMock struct {
 }
 
-func (metricsClientMock) GetMetric(query clients.MetricQuery, clusterName string) (string, error) {
-	return "123", nil
+func (metricsClientMock) GetMetric(query clients.MetricQuery, clusterName string) (*clients.Metric, error) {
+	return &clients.Metric{Name: "test", ScalarValue: float64(123)}, nil
 }
 
 func (metricsClientMock) GetMetricsForCluster(queries []clients.MetricQuery, clusterName string) (map[string]clients.Metric, error) {
 	m := make(map[string]clients.Metric)
 
 	m["numberOfNodes"] = clients.Metric{
-		Name:  "numberOfNodes",
-		Value: "123",
+		Name:        "numberOfNodes",
+		ScalarValue: float64(123),
 	}
 	m["numberOfPods"] = clients.Metric{
-		Name:  "numberOfPods",
-		Value: "321",
+		Name:        "numberOfPods",
+		ScalarValue: float64(321),
 	}
 
 	return m, nil


### PR DESCRIPTION
The change adds support for multidimensional vector metrics, for example:
`sum by (exported_namespace,node) (kube_pod_info)`

Results of the query will be available for Rego rules:

`input.data.monitoring.pods_per_node.vector[namespace][node]`