### PR TITLE
Support for custom prometheus address and basic auth

### DIFF
--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -138,7 +138,10 @@ func (p *PolicyAutomationApp) loadMetricsAPIInputConfig(config *cfg.MetricsAPIIn
 	}
 
 	metricInputBuilder := inputs.NewMetricsInputBuilder(p.ctx, metricQueries).
-		WithCredentialsFile(p.config.CredentialsFile)
+		WithCredentialsFile(p.config.CredentialsFile).
+		WithProjectID(config.ProjectID).
+		WithAddress(config.Address).
+		WithUsernamePassword(config.Username, config.Password)
 
 	metricInput, err := metricInputBuilder.Build()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,9 @@ type K8SAPIInput struct {
 type MetricsAPIInput struct {
 	Enabled   bool           `yaml:"enabled"`
 	ProjectID string         `yaml:"project"`
+	Address   string         `yaml:"address"`
+	Username  string         `yaml:"username"`
+	Password  string         `yaml:"password"`
 	Metrics   []ConfigMetric `yaml:"metrics"`
 }
 type RestInput struct {
@@ -233,6 +236,15 @@ func ValidateScalabilityCheckConfig(config Config) error {
 	}
 	if !config.Inputs.MetricsAPI.Enabled || !config.Inputs.K8sAPI.Enabled {
 		return errors.New("either metricsAPI input or k8sAPI input has to be enabled")
+	}
+	if config.Inputs.MetricsAPI.Enabled {
+		if (config.Inputs.MetricsAPI.Username != "" && config.Inputs.MetricsAPI.Password == "") ||
+			(config.Inputs.MetricsAPI.Password != "" && config.Inputs.MetricsAPI.Username == "") {
+			return errors.New("can't set username without password or password without the username")
+		}
+		if config.Inputs.MetricsAPI.ProjectID != "" && config.Inputs.MetricsAPI.Address != "" {
+			return errors.New("projectID should be not set when custom Prometheus address is specified")
+		}
 	}
 	return nil
 }

--- a/internal/inputs/clients/metrics.go
+++ b/internal/inputs/clients/metrics.go
@@ -218,11 +218,11 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterID st
 					log.Debugf("GetMetric for %s, cluster %s", q, clusterID)
 					metric, err := m.GetMetric(q, clusterID)
 					if err != nil {
-						log.Debugf("unable to get metric: %s", err)
+						log.Debugf("unable to get metric for cluster: %s, query: %s, reason: %s", clusterID, q, err)
 						errorChannel <- err
-						wg.Done()
+					} else {
+						resultsChannel <- metric
 					}
-					resultsChannel <- metric
 				}
 				wg.Done()
 			}()

--- a/internal/inputs/clients/metrics.go
+++ b/internal/inputs/clients/metrics.go
@@ -17,6 +17,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"regexp"
 	"sort"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/google/gke-policy-automation/internal/gke"
 	"github.com/google/gke-policy-automation/internal/log"
+
+	b64 "encoding/base64"
 
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -62,15 +65,15 @@ type metricsClient struct {
 	maxGoRoutines int
 }
 
-func newMetricsClient(ctx context.Context, projectID string, authToken string, maxGoroutines int) (MetricsClient, error) {
+func newMetricsClient(ctx context.Context, address string, roundTripper http.RoundTripper, maxGoroutines int) (MetricsClient, error) {
 	// Creates a client.
 	client, err := api.NewClient(api.Config{
-		Address:      "https://monitoring.googleapis.com/v1/projects/" + projectID + "/location/global/prometheus/",
-		RoundTripper: config.NewAuthorizationCredentialsRoundTripper("Bearer", config.Secret(authToken), api.DefaultRoundTripper),
+		Address:      address,
+		RoundTripper: roundTripper,
 	})
 
 	if err != nil {
-		log.Fatalf("Failed to create metrics client: %v", err)
+		log.Fatalf("failed to create metrics client: %v", err)
 		return nil, err
 	}
 
@@ -87,17 +90,35 @@ func newMetricsClient(ctx context.Context, projectID string, authToken string, m
 type metricsClientBuilder struct {
 	ctx           context.Context
 	projectID     string
-	authToken     string
+	tokenSource   TokenSource
 	maxGoroutines int
 	timeout       int
+	address       string
+	username      string
+	password      string
 }
 
-func NewMetricsClientBuilder(ctx context.Context, projectID string, authToken string) *metricsClientBuilder {
+func NewMetricsClientBuilder(ctx context.Context) *metricsClientBuilder {
 	return &metricsClientBuilder{
-		ctx:       ctx,
-		projectID: projectID,
-		authToken: authToken,
+		ctx: ctx,
 	}
+}
+
+func (b *metricsClientBuilder) WithGoogleCloudMonitoring(projectID string, tokenSource TokenSource) *metricsClientBuilder {
+	b.projectID = projectID
+	b.tokenSource = tokenSource
+	return b
+}
+
+func (b *metricsClientBuilder) WithAddress(address string) *metricsClientBuilder {
+	b.address = address
+	return b
+}
+
+func (b *metricsClientBuilder) WithUsernamePassword(username string, password string) *metricsClientBuilder {
+	b.username = username
+	b.password = password
+	return b
 }
 
 func (b *metricsClientBuilder) WithMaxGoroutines(maxGoroutines int) *metricsClientBuilder {
@@ -111,19 +132,21 @@ func (b *metricsClientBuilder) WithTimeout(timeout int) *metricsClientBuilder {
 }
 
 func (b *metricsClientBuilder) Build() (MetricsClient, error) {
-
-	var maxGoRoutines = defaultMaxGoroutines
-	if b.maxGoroutines != 0 {
-		maxGoRoutines = b.maxGoroutines
+	maxGoRoutines := b.maxGoroutines
+	if b.maxGoroutines == 0 {
+		maxGoRoutines = defaultMaxGoroutines
 	}
 
-	metricsClient, err := newMetricsClient(b.ctx, b.projectID, b.authToken, maxGoRoutines)
+	address := b.address
+	if address == "" {
+		address = fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus/", b.projectID)
+	}
 
+	roundTripper, err := getRoundTripper(b.tokenSource, b.username, b.password)
 	if err != nil {
-		log.Fatalf("failed to create metrics client: %v", err)
 		return nil, err
 	}
-	return metricsClient, nil
+	return newMetricsClient(b.ctx, address, roundTripper, maxGoRoutines)
 }
 
 func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterID string) (*Metric, error) {
@@ -264,4 +287,19 @@ func populateVectorMap(m map[string]interface{}, labels []string, value float64)
 		m[label] = mValue
 	}
 	populateVectorMap(mValue.(map[string]interface{}), labels[1:], value)
+}
+
+func getRoundTripper(ts TokenSource, username, password string) (http.RoundTripper, error) {
+	if ts != nil {
+		authToken, err := ts.GetAuthToken()
+		if err != nil {
+			return nil, err
+		}
+		return config.NewAuthorizationCredentialsRoundTripper("Bearer", config.Secret(authToken), api.DefaultRoundTripper), nil
+	}
+	if username != "" && password != "" {
+		secret := b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+		return config.NewAuthorizationCredentialsRoundTripper("Basic", config.Secret(secret), api.DefaultRoundTripper), nil
+	}
+	return api.DefaultRoundTripper, nil
 }

--- a/internal/inputs/metric_input_test.go
+++ b/internal/inputs/metric_input_test.go
@@ -217,13 +217,6 @@ func TestMetricsInputClose(t *testing.T) {
 	}
 }
 
-func TestCreateTokenSource(t *testing.T) {
-	_, err := createTokenSource(context.Background(), "")
-	if err != nil {
-		t.Fatalf("err = %v; want nil", err)
-	}
-}
-
 func TestCreateTokenSource_credsFile(t *testing.T) {
 	testCredsFile := "test-fixtures/test_credentials.json"
 	_, err := createTokenSource(context.Background(), testCredsFile)

--- a/internal/inputs/metric_input_test.go
+++ b/internal/inputs/metric_input_test.go
@@ -45,45 +45,127 @@ func (metricsClientMock) GetMetricsForCluster(queries []clients.MetricQuery, clu
 }
 
 func TestMetricsInputBuilder(t *testing.T) {
-
 	testCredsFile := "test-fixtures/test_credentials.json"
-	queries := make([]clients.MetricQuery, 2)
+	queries := []clients.MetricQuery{
+		{
+			Name:  "numberOfNodes",
+			Query: "apiserver_storage_objects{resource=\"nodes\"}",
+		},
+		{
+			Name:  "numberOfPods",
+			Query: "apiserver_storage_objects{resource=\"pods\"}",
+		},
+	}
 	numberOfGoroutines := 5
+	clientTimeoutSeconds := 5
 	projectID := "testProject"
-
-	queries[0] = clients.MetricQuery{
-		Name:  "numberOfNodes",
-		Query: "apiserver_storage_objects{resource=\"nodes\"}",
-	}
-	queries[1] = clients.MetricQuery{
-		Name:  "numberOfPods",
-		Query: "apiserver_storage_objects{resource=\"pods\"}",
-	}
 
 	b := NewMetricsInputBuilder(context.Background(), queries).
 		WithCredentialsFile(testCredsFile).
 		WithMaxGoroutines(numberOfGoroutines).
+		WithClientTimeoutSeconds(clientTimeoutSeconds).
 		WithProjectID(projectID)
+
+	b.createTokenSourceFn = func(ctx context.Context, credentialsFile string) (clients.TokenSource, error) {
+		if credentialsFile != testCredsFile {
+			t.Errorf("credentialsFile = %v; want %v", credentialsFile, testCredsFile)
+		}
+		return &tsMock{getAuthTokenFn: func() (string, error) {
+			return "token", nil
+		}}, nil
+	}
 
 	input, err := b.Build()
 	if err != nil {
 		t.Fatalf("err = %v; want nil", err)
 	}
-	metricsInput, ok := input.(*metricsInput)
 	if b.credentialsFile != testCredsFile {
 		t.Errorf("builder credentialsFile = %v; want %v", b.credentialsFile, testCredsFile)
 	}
+	metricsInput, ok := input.(*metricsInput)
 	if !ok {
 		t.Fatalf("input is not *metricsInput")
 	}
+	if metricsInput.credentialsFile != testCredsFile {
+		t.Errorf("credentialsFile = %v; want %v", metricsInput.credentialsFile, testCredsFile)
+	}
 	if metricsInput.maxGoRoutines != numberOfGoroutines {
 		t.Errorf("maxGoRoutines = %v; want %v", metricsInput.maxGoRoutines, numberOfGoroutines)
+	}
+	if metricsInput.timeoutSeconds != clientTimeoutSeconds {
+		t.Errorf("timeoutSeconds = %v; want %v", metricsInput.timeoutSeconds, clientTimeoutSeconds)
 	}
 	if !reflect.DeepEqual(metricsInput.queries, queries) {
 		t.Errorf("queries = %v; want %v", metricsInput.queries, queries)
 	}
 	if metricsInput.projectID != projectID {
 		t.Errorf("projectId = %v; want %v", metricsInput.projectID, projectID)
+	}
+	if metricsInput.metricsClient == nil {
+		t.Error("metricsClient is nil; want clients.MetricClient")
+	}
+}
+
+func TestMetricsInputBuilder_clusterScopedClient(t *testing.T) {
+	testCredsFile := "test-fixtures/test_credentials.json"
+	queries := []clients.MetricQuery{
+		{
+			Name:  "numberOfNodes",
+			Query: "apiserver_storage_objects{resource=\"nodes\"}",
+		},
+		{
+			Name:  "numberOfPods",
+			Query: "apiserver_storage_objects{resource=\"pods\"}",
+		},
+	}
+	b := NewMetricsInputBuilder(context.Background(), queries).
+		WithCredentialsFile(testCredsFile)
+	input, err := b.Build()
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	metricsInput, ok := input.(*metricsInput)
+	if !ok {
+		t.Fatalf("input is not *metricsInput")
+	}
+	if metricsInput.metricsClient != nil {
+		t.Error("metricsClient is not nil; want nil")
+	}
+}
+
+func TestMetricsInputBuilder_customPrometheus(t *testing.T) {
+	address := "http://custom.prometheus.org/api/v1"
+	username := "john"
+	password := "qwerty123"
+	queries := []clients.MetricQuery{
+		{
+			Name:  "numberOfNodes",
+			Query: "apiserver_storage_objects{resource=\"nodes\"}",
+		},
+		{
+			Name:  "numberOfPods",
+			Query: "apiserver_storage_objects{resource=\"pods\"}",
+		},
+	}
+	b := NewMetricsInputBuilder(context.Background(), queries).
+		WithAddress(address).
+		WithUsernamePassword(username, password)
+	input, err := b.Build()
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	metricsInput, ok := input.(*metricsInput)
+	if !ok {
+		t.Fatalf("input is not *metricsInput")
+	}
+	if metricsInput.address != address {
+		t.Fatalf("address = %v; want %v", metricsInput.address, address)
+	}
+	if metricsInput.username != username {
+		t.Fatalf("address = %v; want %v", metricsInput.username, username)
+	}
+	if metricsInput.password != password {
+		t.Fatalf("password = %v; want %v", metricsInput.password, password)
 	}
 }
 
@@ -102,16 +184,16 @@ func TestMetricsInputGetDescription(t *testing.T) {
 }
 
 func TestMetricsInputGetData(t *testing.T) {
-	queries := make([]clients.MetricQuery, 2)
-	queries[0] = clients.MetricQuery{
-		Name:  "numberOfNodes",
-		Query: "apiserver_storage_objects{resource=\"nodes\"}",
+	queries := []clients.MetricQuery{
+		{
+			Name:  "numberOfNodes",
+			Query: "apiserver_storage_objects{resource=\"nodes\"}",
+		},
+		{
+			Name:  "numberOfPods",
+			Query: "apiserver_storage_objects{resource=\"pods\"}",
+		},
 	}
-	queries[1] = clients.MetricQuery{
-		Name:  "numberOfPods",
-		Query: "apiserver_storage_objects{resource=\"pods\"}",
-	}
-
 	projectID := "testProject"
 	clusterID := "projects/testProject/locations/us/clusters/cluster1"
 
@@ -123,6 +205,28 @@ func TestMetricsInputGetData(t *testing.T) {
 	}
 
 	_, err := input.GetData(clusterID)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+}
+
+func TestMetricsInputClose(t *testing.T) {
+	c := metricsInput{}
+	if err := c.Close(); err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+}
+
+func TestCreateTokenSource(t *testing.T) {
+	_, err := createTokenSource(context.Background(), "")
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+}
+
+func TestCreateTokenSource_credsFile(t *testing.T) {
+	testCredsFile := "test-fixtures/test_credentials.json"
+	_, err := createTokenSource(context.Background(), testCredsFile)
 	if err != nil {
 		t.Fatalf("err = %v; want nil", err)
 	}

--- a/internal/inputs/metrics_input.go
+++ b/internal/inputs/metrics_input.go
@@ -100,7 +100,7 @@ func (b *metricsInputBuilder) Build() (Input, error) {
 	var metricsClient clients.MetricsClient
 	var err error
 	if b.projectID != "" || b.address != "" {
-		log.Debugf("creating global metric client with a project %s", b.projectID)
+		log.Debugf("creating global metric client, project %q, address %q", b.projectID, b.address)
 		if metricsClient, err = newMetricsClientFromBuilder(b.ctx,
 			b.credentialsFile, b.address, b.projectID, b.username, b.password,
 			b.maxGoRoutines, b.timeoutSeconds, b.createTokenSourceFn); err != nil {


### PR DESCRIPTION
* Added support for custom prometheus server address
* Added support for basic HTTP auth for the above (the only supported way by prometheus instances for now)
* `metricsClient` is created for every cluster, when `projectID` for the input is not configured 