### PR TITLE
Error from empty query result was not reported

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 
@@ -123,6 +124,9 @@ func (p *PolicyAutomationApp) CheckBestPractices() error {
 }
 
 func (p *PolicyAutomationApp) CheckScalability() error {
+	p.out.ColorPrintf("%s [yellow][bold]Running scalability check requires metrics from kube-state-metrics!\n", outputs.IconInfo)
+	docsTitle := fmt.Sprintf("%s \x1b]8;;%s\x07%s\x1b]8;;\x07", outputs.IconHyperlink, "https://github.com/google/gke-policy-automation/blob/scalability-docs/docs/user-guide.md#checking-scalability-limits", "documentation")
+	p.out.ColorPrintf("%s [yellow][bold]Check the %s for more details.\n", outputs.IconInfo, docsTitle)
 	return p.evaluateClusters([]string{regoPackageBaseScalability})
 }
 

--- a/internal/inputs/clients/metrics.go
+++ b/internal/inputs/clients/metrics.go
@@ -171,7 +171,7 @@ func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterID string) (*M
 	}
 
 	if len(data) < 1 {
-		return nil, fmt.Errorf("empty result vector")
+		return nil, fmt.Errorf("query returned no results")
 	}
 
 	if data.Len() == 1 {
@@ -234,8 +234,7 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterID st
 
 	}()
 
-	if len(errorChannel) > 0 {
-		err := <-errorChannel
+	for err := range errorChannel {
 		log.Errorf("unable to get metric: %s", err)
 		return nil, err
 	}
@@ -247,7 +246,6 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterID st
 
 func replaceWildcard(wildcard string, value string, query string) string {
 	clusterNameExp := regexp.MustCompile(wildcard)
-
 	return clusterNameExp.ReplaceAllString(query, "\""+value+"\"")
 }
 

--- a/internal/inputs/clients/metrics.go
+++ b/internal/inputs/clients/metrics.go
@@ -54,6 +54,14 @@ type Metric struct {
 	VectorValue map[string]interface{} `json:"vector"`
 }
 
+type emptyResultError struct {
+	msg string
+}
+
+func (e emptyResultError) Error() string {
+	return e.msg
+}
+
 type MetricsClient interface {
 	GetMetric(query MetricQuery, clusterID string) (*Metric, error)
 	GetMetricsForCluster(queries []MetricQuery, clusterID string) (map[string]Metric, error)
@@ -171,7 +179,9 @@ func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterID string) (*M
 	}
 
 	if len(data) < 1 {
-		return nil, fmt.Errorf("query returned no results")
+		return nil, &emptyResultError{
+			msg: fmt.Sprintf("metric query %q returned no results", query),
+		}
 	}
 
 	if data.Len() == 1 {
@@ -184,6 +194,9 @@ func (m *metricsClient) GetMetric(metricQuery MetricQuery, clusterID string) (*M
 	vectorValue := make(map[string]interface{})
 	for _, dataSample := range data {
 		metricValues := valuesFromMetric(dataSample.Metric)
+		if len(metricValues) < 1 {
+			return nil, fmt.Errorf("metric query result has no labels")
+		}
 		populateVectorMap(vectorValue, metricValues, float64(dataSample.Value))
 	}
 	return &Metric{
@@ -235,8 +248,12 @@ func (m *metricsClient) GetMetricsForCluster(queries []MetricQuery, clusterID st
 	}()
 
 	for err := range errorChannel {
-		log.Errorf("unable to get metric: %s", err)
-		return nil, err
+		switch err.(type) {
+		case *emptyResultError:
+			log.Warnf("metric fetch error: %s", err)
+		default:
+			return nil, err
+		}
 	}
 	for result := range resultsChannel {
 		metricsResult[result.Name] = *result
@@ -275,6 +292,9 @@ func valuesFromMetric(metric pmodel.Metric) []string {
 }
 
 func populateVectorMap(m map[string]interface{}, labels []string, value float64) {
+	if len(labels) < 1 {
+		return
+	}
 	if len(labels) == 1 {
 		m[labels[0]] = value
 		return


### PR DESCRIPTION
There was no error reported when metric query produced empty result. The root cause was in error channel handling.