### PR TITLE
Added anchors to cluster asset regex for security

### DIFF
--- a/internal/gke/discovery.go
+++ b/internal/gke/discovery.go
@@ -162,7 +162,7 @@ func filterMapSeachResults(results []*assetpb.ResourceSearchResult) []string {
 
 // getIDFromName returns cluster identifier from full cluster asset name.
 func getIDFromName(name string) (string, error) {
-	r := regexp.MustCompile(`//container\.googleapis\.com/(projects/.+/(locations|zones)/.+/clusters/.+)`)
+	r := regexp.MustCompile(`^//container\.googleapis\.com/(projects/.+/(locations|zones)/.+/clusters/.+$)`)
 	if !r.MatchString(name) {
 		return "", fmt.Errorf("given name %q does not match GKE cluster name pattern", name)
 	}

--- a/internal/gke/discovery_test.go
+++ b/internal/gke/discovery_test.go
@@ -199,6 +199,7 @@ func TestGetIDFromName_negative(t *testing.T) {
 	inputs := []string{
 		"projects/my-project/locations/europe-west2/clusters/my-cluster",
 		"//container.googleapis.com/project/test/locations/europe/my-cluster",
+		"malicious//container.googleapis.com/projects/my-project/locations/europe-west2/clusters/other-cluster/code",
 	}
 	for _, input := range inputs {
 		if _, err := getIDFromName(input); err == nil {


### PR DESCRIPTION
Fix for [#1 Missing regular expression anchor](https://github.com/google/gke-policy-automation/security/code-scanning/1).