### PR TITLE
Add Regal for linting Rego

### DIFF
--- a/.github/workflows/policy-test.yml
+++ b/.github/workflows/policy-test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2
         with:
@@ -40,3 +40,8 @@ jobs:
         run: opa test ${{ env.GKE_POLICY_DIRECTORY_V1 }} -v
       - name: Run Policy tests - v2 policies
         run: opa test ${{ env.GKE_POLICY_DIRECTORY_V2 }} -v
+      - name: Setup Regal
+        uses: StyraInc/setup-regal@v0.2.0
+        with:
+          version: v0.10.1
+      - run: regal lint --format github ${{ env.GKE_POLICY_DIRECTORY_V2 }}

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package gke.rule.cluster.location
-
-regional(location) {
-  regex.match(`^[^-]+-[^-]+$`, location)
-}
-
-zonal(location) {
-    regex.match(`^[^-]+-[^-]+-[^-]+$`, location)
-}
+rules:
+  idiomatic:
+    no-defined-entrypoint:
+      # not applicable to this project
+      level: ignore
+  style:
+    detached-metadata:
+      # style preference only
+      level: ignore
+    line-length:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      level: ignore

--- a/gke-policies-v2/AUTHORING.md
+++ b/gke-policies-v2/AUTHORING.md
@@ -76,7 +76,7 @@ Below is an example of a valid GKE Policy file.
 #   group: Security
 package gke.policy.control_plane_access
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0

--- a/gke-policies-v2/policy/autopilot_cluster.rego
+++ b/gke-policies-v2/policy/autopilot_cluster.rego
@@ -19,7 +19,7 @@
 #   group: Management
 #   severity: Medium
 #   recommendation: >
-#     Autopilot mode (recommended): GKE manages the underlying infrastructure such as node configuration, 
+#     Autopilot mode (recommended): GKE manages the underlying infrastructure such as node configuration,
 #     autoscaling, auto-upgrades, baseline security configurations, and baseline networking configuration.
 #   externalURI: https://cloud.google.com/kubernetes-engine/docs/concepts/choose-cluster-mode
 #   sccCategory: AUTOPILOT_DISABLED
@@ -27,7 +27,7 @@
 
 package gke.policy.autopilot
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/cluster_binary_authorization.rego
+++ b/gke-policies-v2/policy/cluster_binary_authorization.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.cluster_binary_authorization
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0

--- a/gke-policies-v2/policy/cluster_gce_csi_driver.rego
+++ b/gke-policies-v2/policy/cluster_gce_csi_driver.rego
@@ -28,7 +28,7 @@
 
 package gke.policy.cluster_gce_csi_driver
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0

--- a/gke-policies-v2/policy/cluster_gce_csi_driver_test.rego
+++ b/gke-policies-v2/policy/cluster_gce_csi_driver_test.rego
@@ -18,7 +18,7 @@ test_gce_csi_driver_addon_empty {
     not valid with input as {"data": {"gke": {"name":"cluster-demo","addons_config":{"gce_persistent_disk_csi_driver_config":{}}}}}
 }
 
-test_gce_csi_driver_addon_empty {
+test_gce_csi_driver_addon_disabled {
     not valid with input as {"data": {"gke": {"name":"cluster-demo","addons_config":{"gce_persistent_disk_csi_driver_config":{"enabled":false}}}}}
 }
 

--- a/gke-policies-v2/policy/cluster_maintenance_window.rego
+++ b/gke-policies-v2/policy/cluster_maintenance_window.rego
@@ -30,7 +30,7 @@
 
 package gke.policy.cluster_maintenance_window
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0

--- a/gke-policies-v2/policy/cluster_receive_updates.rego
+++ b/gke-policies-v2/policy/cluster_receive_updates.rego
@@ -30,16 +30,18 @@
 
 package gke.policy.cluster_receive_updates
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
 violation[msg] {
-  not input.data.gke.notification_config.pubsub.enabled 
+  not input.data.gke.notification_config.pubsub.enabled
   msg := "Pub/Sub notifications are not enabled"
-} {
-  not input.data.gke.notification_config.pubsub.topic 
+}
+
+violation[msg] {
+  not input.data.gke.notification_config.pubsub.topic
   msg := "Pub/Sub topic is not configured"
 }

--- a/gke-policies-v2/policy/cluster_release_channels.rego
+++ b/gke-policies-v2/policy/cluster_release_channels.rego
@@ -32,13 +32,13 @@
 
 package gke.policy.cluster_release_channels
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
 violation[msg] {
-  not input.data.gke.release_channel.channel  
+  not input.data.gke.release_channel.channel
   msg := "GKE cluster is not enrolled in release channel"
 }

--- a/gke-policies-v2/policy/control_plane_access.rego
+++ b/gke-policies-v2/policy/control_plane_access.rego
@@ -33,7 +33,7 @@
 
 package gke.policy.control_plane_access
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
@@ -41,15 +41,15 @@ valid {
 
 violation[msg] {
   not input.data.gke.master_authorized_networks_config.enabled
-  msg := "GKE cluster has not enabled master authorized networks configuration" 
+  msg := "GKE cluster has not enabled master authorized networks configuration"
 }
 
 violation[msg] {
   not input.data.gke.master_authorized_networks_config.cidr_blocks
-  msg := "GKE cluster's master authorized networks has no CIDR blocks element" 
+  msg := "GKE cluster's master authorized networks has no CIDR blocks element"
 }
 
 violation[msg] {
   count(input.data.gke.master_authorized_networks_config.cidr_blocks) < 1
-  msg := "GKE cluster's master authorized networks has no CIDR blocks defined" 
+  msg := "GKE cluster's master authorized networks has no CIDR blocks defined"
 }

--- a/gke-policies-v2/policy/control_plane_disable_legacy_authorization.rego
+++ b/gke-policies-v2/policy/control_plane_disable_legacy_authorization.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.disable_legacy_authorization
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/control_plane_endpoint.rego
+++ b/gke-policies-v2/policy/control_plane_endpoint.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.control_plane_endpoint
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
@@ -39,5 +39,5 @@ valid {
 
 violation[msg] {
   not input.data.gke.private_cluster_config.enable_private_endpoint
-  msg := "GKE cluster has not enabled private endpoint" 
+  msg := "GKE cluster has not enabled private endpoint"
 }

--- a/gke-policies-v2/policy/control_plane_redundancy.rego
+++ b/gke-policies-v2/policy/control_plane_redundancy.rego
@@ -27,9 +27,9 @@
 
 package gke.policy.control_plane_redundancy
 
-import data.gke.rule.cluster.location.regional
+import data.gke.rule.cluster.location
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
@@ -41,6 +41,6 @@ violation[msg] {
 }
 
 violation[msg] {
-  not regional(input.data.gke.location)
+  not location.regional(input.data.gke.location)
   msg := sprintf("Invalid GKE Control plane location %q (not regional)", [input.data.gke.location])
 }

--- a/gke-policies-v2/policy/ilb_subsetting.rego
+++ b/gke-policies-v2/policy/ilb_subsetting.rego
@@ -28,7 +28,7 @@
 
 package gke.policy.enable_ilb_subsetting
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/monitoring_and_logging.rego
+++ b/gke-policies-v2/policy/monitoring_and_logging.rego
@@ -35,7 +35,7 @@
 
 package gke.policy.logging_and_monitoring
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/nap_forbid_default_sa.rego
+++ b/gke-policies-v2/policy/nap_forbid_default_sa.rego
@@ -32,7 +32,7 @@
 
 package gke.policy.nap_forbid_default_sa
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/nap_forbid_single_zone.rego
+++ b/gke-policies-v2/policy/nap_forbid_single_zone.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.nap_forbid_single_zone
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/nap_integrity_monitoring.rego
+++ b/gke-policies-v2/policy/nap_integrity_monitoring.rego
@@ -36,7 +36,7 @@
 
 package gke.policy.nap_integrity_monitoring
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0
@@ -45,6 +45,6 @@ valid {
 violation[msg] {
 	input.data.gke.autoscaling.enable_node_autoprovisioning == true
 	input.data.gke.autoscaling.autoprovisioning_node_pool_defaults.shielded_instance_config.enable_integrity_monitoring == false
-	
+
 	msg := "GKE cluster Node Auto-Provisioning configuration use integrity monitoring"
 }

--- a/gke-policies-v2/policy/nap_use_cos.rego
+++ b/gke-policies-v2/policy/nap_use_cos.rego
@@ -33,7 +33,7 @@ package gke.policy.nap_use_cos
 
 import future.keywords.in
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0
@@ -42,6 +42,6 @@ valid {
 violation[msg] {
 	input.data.gke.autoscaling.enable_node_autoprovisioning == true
 	not lower(input.data.gke.autoscaling.autoprovisioning_node_pool_defaults.image_type) in { "cos", "cos_containerd"}
-	
+
 	msg := "GKE cluster Node Auto-Provisioning configuration use Container-Optimized OS"
 }

--- a/gke-policies-v2/policy/network_policies.rego
+++ b/gke-policies-v2/policy/network_policies.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.network_policies_engine
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/node_local_dns_cache.rego
+++ b/gke-policies-v2/policy/node_local_dns_cache.rego
@@ -28,7 +28,7 @@
 
 package gke.policy.node_local_dns_cache
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/node_pool_autorepair.rego
+++ b/gke-policies-v2/policy/node_pool_autorepair.rego
@@ -32,15 +32,14 @@
 
 package gke.policy.node_pool_autorepair
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].management.auto_repair
   msg := sprintf("autorepair not set for GKE node pool %q", [input.data.gke.node_pools[pool].name])
-} 
-
-
+}

--- a/gke-policies-v2/policy/node_pool_autoscaling.rego
+++ b/gke-policies-v2/policy/node_pool_autoscaling.rego
@@ -30,13 +30,14 @@
 
 package gke.policy.node_pool_autoscaling
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
 violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].autoscaling.enabled
   msg := sprintf("Node pool %q does not have autoscaling configured.", [input.data.gke.node_pools[pool].name])
 }

--- a/gke-policies-v2/policy/node_pool_autoupgrade.rego
+++ b/gke-policies-v2/policy/node_pool_autoupgrade.rego
@@ -32,14 +32,14 @@
 
 package gke.policy.node_pool_autoupgrade
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
 violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].management.auto_upgrade
   msg := sprintf("autoupgrade not set for GKE node pool %q", [input.data.gke.node_pools[pool].name])
-} 
-
+}

--- a/gke-policies-v2/policy/node_pool_forbid_default_sa.rego
+++ b/gke-policies-v2/policy/node_pool_forbid_default_sa.rego
@@ -32,7 +32,7 @@
 
 package gke.policy.node_pool_forbid_default_sa
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0
@@ -40,6 +40,7 @@ valid {
 
 violation[msg] {
 	not input.data.gke.autopilot.enabled
+	some pool
 	input.data.gke.node_pools[pool].config.service_account == "default"
 	msg := sprintf("GKE cluster node_pool %q should have a dedicated SA", [input.data.gke.node_pools[pool].name])
 }

--- a/gke-policies-v2/policy/node_pool_integrity_monitoring.rego
+++ b/gke-policies-v2/policy/node_pool_integrity_monitoring.rego
@@ -31,13 +31,14 @@
 
 package gke.policy.node_pool_integrity_monitoring
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].config.shielded_instance_config.enable_integrity_monitoring
   msg := sprintf("Node pool %q has disabled integrity monitoring feature.", [input.data.gke.node_pools[pool].name])
-} 
+}

--- a/gke-policies-v2/policy/node_pool_multi_zone.rego
+++ b/gke-policies-v2/policy/node_pool_multi_zone.rego
@@ -29,13 +29,14 @@
 
 package gke.policy.node_pool_multi_zone
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
+  some pool
   count(input.data.gke.node_pools[pool].locations) < 2
   msg := sprintf("Node pool %q is not on multiple zones.", [input.data.gke.node_pools[pool].name])
-} 
+}

--- a/gke-policies-v2/policy/node_pool_secure_boot.rego
+++ b/gke-policies-v2/policy/node_pool_secure_boot.rego
@@ -31,13 +31,14 @@
 
 package gke.policy.node_pool_secure_boot
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].config.shielded_instance_config.enable_secure_boot
   msg := sprintf("Node pool %q has disabled secure boot.", [input.data.gke.node_pools[pool].name])
-} 
+}

--- a/gke-policies-v2/policy/node_pool_use_cos.rego
+++ b/gke-policies-v2/policy/node_pool_use_cos.rego
@@ -35,13 +35,14 @@ package gke.policy.node_pool_use_cos
 
 import future.keywords.in
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
+  some pool
   not lower(input.data.gke.node_pools[pool].config.image_type) in {"cos", "cos_containerd"}
   msg := sprintf("Node pool %q does not use Container-Optimized OS.", [input.data.gke.node_pools[pool].name])
-} 
+}

--- a/gke-policies-v2/policy/node_pool_version_skew.rego
+++ b/gke-policies-v2/policy/node_pool_version_skew.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.node_pool_version_skew
 
-default valid = false
+default valid := false
 
 expr := `^([0-9]+)\.([0-9]+)\.([0-9]+)(-.+)*$`
 

--- a/gke-policies-v2/policy/node_rbac_security_group.rego
+++ b/gke-policies-v2/policy/node_rbac_security_group.rego
@@ -34,13 +34,13 @@
 
 package gke.policy.rbac_security_group_enabled
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
-violation[msg] {  
+violation[msg] {
   not input.data.gke.authenticator_groups_config.enabled
   msg := sprintf("RBAC security group not enabled for cluster %q", [input.data.gke.name])
 }

--- a/gke-policies-v2/policy/private_cluster.rego
+++ b/gke-policies-v2/policy/private_cluster.rego
@@ -30,7 +30,7 @@
 
 package gke.policy.private_cluster
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0

--- a/gke-policies-v2/policy/secret_encryption.rego
+++ b/gke-policies-v2/policy/secret_encryption.rego
@@ -33,7 +33,7 @@
 
 package gke.policy.secret_encryption
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/shielded_nodes.rego
+++ b/gke-policies-v2/policy/shielded_nodes.rego
@@ -31,7 +31,7 @@
 
 package gke.policy.shielded_nodes
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/policy/vpc_native_cluster.rego
+++ b/gke-policies-v2/policy/vpc_native_cluster.rego
@@ -28,13 +28,14 @@
 
 package gke.policy.vpc_native_cluster
 
-default valid = false
+default valid := false
 
 valid {
   count(violation) == 0
 }
 
 violation[msg] {
+  some pool
   not input.data.gke.node_pools[pool].network_config.pod_ipv4_cidr_block
   msg := sprintf("Nodepool %q of the GKE cluster is not configured to use VPC-native routing", [input.data.gke.node_pools[pool].name])
 }

--- a/gke-policies-v2/policy/workload_identity.rego
+++ b/gke-policies-v2/policy/workload_identity.rego
@@ -33,7 +33,7 @@
 
 package gke.policy.workload_identity
 
-default valid = false
+default valid := false
 
 valid {
 	count(violation) == 0

--- a/gke-policies-v2/scalability/limit_namespaces.rego
+++ b/gke-policies-v2/scalability/limit_namespaces.rego
@@ -27,16 +27,16 @@
 
 package gke.scalability.namespaces
 
-default valid = false
-default limit = 10000
-default threshold = 80
+default valid := false
+default limit := 10000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
+	warn_limit := round(limit * threshold * 0.01)
     input.data.monitoring.namespaces.scalar > warn_limit
 	msg := sprintf("Total number of namespaces %d has reached warning level %d (limit is %d)", [input.data.monitoring.namespaces.scalar, warn_limit, limit])
 }

--- a/gke-policies-v2/scalability/limit_secrets_encryption.rego
+++ b/gke-policies-v2/scalability/limit_secrets_encryption.rego
@@ -27,16 +27,16 @@
 
 package gke.scalability.secrets_with_enc
 
-default valid = false
-default limit = 30000
-default threshold = 80
+default valid := false
+default limit := 30000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
+	warn_limit := round(limit * threshold * 0.01)
     secrets_cnt := input.data.monitoring.secrets.scalar
 	input.data.gke.database_encryption.state == 1
     secrets_cnt> warn_limit

--- a/gke-policies-v2/scalability/limit_services.rego
+++ b/gke-policies-v2/scalability/limit_services.rego
@@ -28,16 +28,16 @@
 
 package gke.scalability.services
 
-default valid = false
-default limit = 10000
-default threshold = 80
+default valid := false
+default limit := 10000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
+	warn_limit := round(limit * threshold * 0.01)
     input.data.monitoring.services.scalar > warn_limit
 	msg := sprintf("Total number of services %d has reached warning level %d (limit is %d)", [input.data.monitoring.services.scalar, warn_limit, limit])
 }

--- a/gke-policies-v2/scalability/limit_services_per_ns.rego
+++ b/gke-policies-v2/scalability/limit_services_per_ns.rego
@@ -28,16 +28,16 @@
 
 package gke.scalability.services_per_ns
 
-default valid = false
-default limit = 5000
-default threshold = 80
+default valid := false
+default limit := 5000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
+	warn_limit := round(limit * threshold * 0.01)
 	some namespace
 	srv_cnt := input.data.monitoring.services_per_ns.vector[namespace]
     srv_cnt > warn_limit

--- a/gke-policies-v2/scalability/limits_containers.rego
+++ b/gke-policies-v2/scalability/limits_containers.rego
@@ -27,24 +27,24 @@
 
 package gke.scalability.containers
 
-default valid = false
-default limit_standard = 400000
-default limit_autopilot = 24000
-default threshold = 80
+default valid := false
+default limit_standard := 400000
+default limit_autopilot := 24000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit_standard * threshold * 0.01)
+	warn_limit := round(limit_standard * threshold * 0.01)
 	not input.data.gke.autopilot.enabled
     input.data.monitoring.containers.scalar > warn_limit
 	msg := sprintf("Total number of containers %d has reached warning level %d (limit is %d for standard clusters)", [input.data.monitoring.containers.scalar, warn_limit, limit_standard])
 }
 
 violation[msg] {
-	warn_limit = round(limit_autopilot * threshold * 0.01)
+	warn_limit := round(limit_autopilot * threshold * 0.01)
 	input.data.gke.autopilot.enabled
     input.data.monitoring.containers.scalar > warn_limit
 	msg := sprintf("Total number of containers %d has reached warning level %d (limit is %d for autopilot clusters)", [input.data.monitoring.containers.scalar, warn_limit, limit_autopilot])

--- a/gke-policies-v2/scalability/limits_hpas.rego
+++ b/gke-policies-v2/scalability/limits_hpas.rego
@@ -27,17 +27,17 @@
 
 package gke.scalability.hpas
 
-default valid = false
-default limit = 300
-default threshold = 80
+default valid := false
+default limit := 300
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
-	hpas := input.data.monitoring.hpas.scalar 
+	warn_limit := round(limit * threshold * 0.01)
+	hpas := input.data.monitoring.hpas.scalar
 	hpas > warn_limit
 	msg := sprintf("Total number of HPAs %d has reached warning level %d (limit is %d)", [hpas, warn_limit, limit])
 }

--- a/gke-policies-v2/scalability/limits_nodes.rego
+++ b/gke-policies-v2/scalability/limits_nodes.rego
@@ -29,38 +29,38 @@
 
 package gke.scalability.nodes
 
-default valid = false
+default valid := false
 
-default private_nodes_limit = 15000
-default public_nodes_limit = 5000
-default autopilot_nodes_limit = 1000
-default threshold = 80
+default private_nodes_limit := 15000
+default public_nodes_limit := 5000
+default autopilot_nodes_limit := 1000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(private_nodes_limit * threshold * 0.01)
-	nodes := input.data.monitoring.nodes.scalar 
+	warn_limit := round(private_nodes_limit * threshold * 0.01)
+	nodes := input.data.monitoring.nodes.scalar
 	is_private := input.data.gke.private_cluster_config.enable_private_nodes
-	is_private = true 
+	is_private = true
 	nodes > warn_limit
 	msg := sprintf("nodes found: %d higher than the limit for private clusters: %d", [nodes, warn_limit])
 }
 
 violation[msg] {
-	warn_limit = round(public_nodes_limit * threshold * 0.01)
-	nodes := input.data.monitoring.nodes.scalar 
+	warn_limit := round(public_nodes_limit * threshold * 0.01)
+	nodes := input.data.monitoring.nodes.scalar
 	is_private := input.data.gke.private_cluster_config.enable_private_nodes
-	is_private = false 
+	is_private = false
 	nodes > warn_limit
 	msg := sprintf("nodes found: %d higher than the limit for non private clusters: %d", [nodes, warn_limit])
 }
 
 violation[msg] {
-	warn_limit = round(autopilot_nodes_limit * threshold * 0.01)
-	nodes := input.data.monitoring.nodes.scalar 
+	warn_limit := round(autopilot_nodes_limit * threshold * 0.01)
+	nodes := input.data.monitoring.nodes.scalar
 	input.data.gke.autopilot.enabled
 	nodes > warn_limit
 	msg := sprintf("nodes found: %d higher than the warn limit for autopilot clusters: %d", [nodes, warn_limit])

--- a/gke-policies-v2/scalability/limits_nodes_per_pool_zone.rego
+++ b/gke-policies-v2/scalability/limits_nodes_per_pool_zone.rego
@@ -28,16 +28,16 @@
 
 package gke.scalability.nodes_per_pool_zone
 
-default valid = false
-default limit = 1000
-default threshold = 80
+default valid := false
+default limit := 1000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit * threshold * 0.01)
+	warn_limit := round(limit * threshold * 0.01)
 	some nodepool, zone
 	not input.data.gke.autopilot.enabled
     nodes_cnt := input.data.monitoring.nodes_per_pool_zone.vector[nodepool][zone]

--- a/gke-policies-v2/scalability/limits_pods.rego
+++ b/gke-policies-v2/scalability/limits_pods.rego
@@ -27,24 +27,24 @@
 
 package gke.scalability.pods
 
-default valid = false
-default limit_standard = 200000
-default limit_autopilot = 12000
-default threshold = 80
+default valid := false
+default limit_standard := 200000
+default limit_autopilot := 12000
+default threshold := 80
 
 valid {
 	count(violation) == 0
 }
 
 violation[msg] {
-	warn_limit = round(limit_standard * threshold * 0.01)
+	warn_limit := round(limit_standard * threshold * 0.01)
 	not input.data.gke.autopilot.enabled
     input.data.monitoring.pods.scalar > warn_limit
 	msg := sprintf("Total number of pods %d has reached warning level %d (limit is %d for standard clusters)", [input.data.monitoring.pods.scalar, warn_limit, limit_standard])
 }
 
 violation[msg] {
-	warn_limit = round(limit_autopilot * threshold * 0.01)
+	warn_limit := round(limit_autopilot * threshold * 0.01)
 	input.data.gke.autopilot
 	input.data.gke.autopilot.enabled
     input.data.monitoring.pods.scalar > warn_limit

--- a/gke-policies-v2/scalability/limits_pods_per_node.rego
+++ b/gke-policies-v2/scalability/limits_pods_per_node.rego
@@ -28,8 +28,8 @@
 
 package gke.scalability.pods_per_node
 
-default valid = false
-default threshold = 80
+default valid := false
+default threshold := 80
 
 valid {
 	count(violation) == 0


### PR DESCRIPTION
Hi there, GKE friends 👋😃

This PR introduces [Regal](https://github.com/StyraInc/regal) for linting Rego policy for the project. I've limited linting (and fixes) to the `gke-policies-v2` directory here, but I'd be happy to expand this to the v1 directory as well if you think that'd be valuable.

Along with a configuration file to disable some of the linters that'd require a more concentrated effort to adhere to, I've fixed the following reported violations, which while mostly style-related, seems like they'd be good to enforce for modern Rego:

* [use-some-for-output-vars](https://docs.styra.com/regal/rules/use-some-for-output-vars)
* [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)
* [prefer-package-imports](https://docs.styra.com/regal/rules/imports/prefer-package-imports)
* [chained-rule-body](https://docs.styra.com/regal/rules/style/chained-rule-body)
* [identically-named-tests](https://docs.styra.com/regal/rules/testing/identically-named-tests)
* [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)

I've also included linting as a step for the GitHub Action that runs tests of all the policies.

Let me know what you think!