### PR TITLE
Krew automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,5 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ dockers:
       - "ghcr.io/google/{{ .ProjectName }}:{{ .ShortCommit }}" 
 archives:
   - format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - gke-policy
     files:
@@ -56,7 +56,7 @@ archives:
       - README*
       - CHANGELOG*
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,100 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gke-policy
+spec:
+  shortDescription: Validates GKE clusters configuration
+  homepage: https://github.com/google/gke-policy-automation
+  description: |
+    Tool and policy library for validating Google Kubernetes Engine clusters
+    against the configuration best practices and scalability limits.
+  caveats: |
+    The plugin requires Google Cloud credentials to work.
+    Use "gcloud auth application-default login" command to authenticate or
+    specify credentials file as an argument.
+  version: {{ .TagName }}
+  platforms:
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: linux
+          arch: 386
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_386.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_arm.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_amd64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_arm64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: windows
+          arch: 386
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_386.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: windows
+          arch: arm
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_arm.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_amd64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_arm64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: freebsd
+          arch: 386
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_386.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: freebsd
+          arch: arm
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_arm.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: freebsd
+          arch: amd64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_amd64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: freebsd
+          arch: arm64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_arm64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_darwin_amd64.zip" .TagName }}
+    - bin: gke-policy
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_darwin_arm64.zip" .TagName }}

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -18,12 +18,6 @@ spec:
       selector:
         matchLabels:
           os: linux
-          arch: 386
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_386.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: linux
           arch: arm
       {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_arm.zip" .TagName }}
     - bin: gke-policy
@@ -38,54 +32,18 @@ spec:
           os: linux
           arch: arm64
       {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_linux_arm64.zip" .TagName }}
-    - bin: gke-policy
+    - bin: gke-policy.exe
       selector:
         matchLabels:
           os: windows
           arch: 386
       {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_386.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: windows
-          arch: arm
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_arm.zip" .TagName }}
-    - bin: gke-policy
+    - bin: gke-policy.exe
       selector:
         matchLabels:
           os: windows
           arch: amd64
       {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_amd64.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: windows
-          arch: arm64
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_windows_arm64.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: freebsd
-          arch: 386
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_386.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: freebsd
-          arch: arm
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_arm.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: freebsd
-          arch: amd64
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_amd64.zip" .TagName }}
-    - bin: gke-policy
-      selector:
-        matchLabels:
-          os: freebsd
-          arch: arm64
-      {{addURIAndSha "https://github.com/google/gke-policy-automation/releases/download/{{ .TagName }}/gke-policy-automation_{{ .TagName }}_freebsd_arm64.zip" .TagName }}
     - bin: gke-policy
       selector:
         matchLabels:


### PR DESCRIPTION
Fixes #105 
Adds release automation for krew plugin installation. The tool was introduced as a krew plugin in https://github.com/kubernetes-sigs/krew-index/pull/3450