### PR TITLE
Add named policy lists for exclusions

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -338,16 +338,25 @@ Example:
 ### Excluding policies
 
 Specific policies or policy groups may be excluded during cluster review. Policy exclusion can only
-be configured using a [configuration file](#configuration-file). The below example skips all REGO
-policies in the `Scalability` group as well as the specific policy
-`gke.policy.cluster_binary_authorization`.
+be configured using a [configuration file](#configuration-file). Named policy lists can be defined
+once and referenced from `policyExclusions.policyLists` when the same set of policies should be
+reused across configurations. The below example skips all REGO policies in the `Scalability` group,
+the specific policy `gke.policy.cluster_binary_authorization`, and every policy in the
+`baseline-security` policy list.
 
 ```yaml
+policyLists:
+  - name: baseline-security
+    policies:
+      - gke.policy.private_cluster
+      - gke.policy.workload_identity
 policyExclusions:
   policies:
     - gke.policy.cluster_binary_authorization
   policyGroups:
     - Scalability
+  policyLists:
+    - baseline-security
 ```
 
 ## Inputs
@@ -574,11 +583,18 @@ policies:
     branch: main
     directory: gke-policies
   - local: ./my-policies
+policyLists:
+  - name: baseline-security
+    policies:
+      - gke.policy.private_cluster
+      - gke.policy.workload_identity
 policyExclusions:
   policies:
     - gke.policy.enable_ilb_subsetting
   policyGroups:
     - Scalability
+  policyLists:
+    - baseline-security
 outputs:
   - file: output-file.json
   - pubsub:

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -54,6 +54,9 @@ func (p *PolicyAutomationApp) LoadCliConfig(cliConfig *CliConfig, defaultsFn set
 }
 
 func (p *PolicyAutomationApp) LoadConfig(config *cfg.Config) error {
+	if err := cfg.ResolvePolicyExclusions(config); err != nil {
+		return err
+	}
 	p.config = config
 	if p.config.JSONOutput {
 		p.collectors = []outputs.ValidationResultCollector{outputs.NewConsoleJSONResultCollector(outputs.NewStdOutOutput())}

--- a/internal/app/app_config_test.go
+++ b/internal/app/app_config_test.go
@@ -126,6 +126,32 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_resolvesPolicyLists(t *testing.T) {
+	config := &cfg.Config{
+		PolicyExclusions: cfg.ConfigPolicyExclusions{
+			Policies:    []string{"gke.policy.private_cluster"},
+			PolicyLists: []string{"baseline"},
+		},
+		PolicyLists: []cfg.ConfigPolicyList{
+			{
+				Name: "baseline",
+				Policies: []string{
+					"gke.policy.private_cluster",
+					"gke.policy.workload_identity",
+				},
+			},
+		},
+	}
+	pa := PolicyAutomationApp{ctx: context.Background()}
+	if err := pa.LoadConfig(config); err != nil {
+		t.Fatalf("err is not nil; want nil; err = %s", err)
+	}
+	expected := []string{"gke.policy.private_cluster", "gke.policy.workload_identity"}
+	if !reflect.DeepEqual(pa.config.PolicyExclusions.Policies, expected) {
+		t.Errorf("policy exclusions = %v; want %v", pa.config.PolicyExclusions.Policies, expected)
+	}
+}
+
 func TestNewConfigFromCli(t *testing.T) {
 	input := &CliConfig{
 		SilentMode:      true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Outputs          []ConfigOutput         `yaml:"outputs"`
 	ClusterDiscovery ClusterDiscovery       `yaml:"clusterDiscovery"`
 	PolicyExclusions ConfigPolicyExclusions `yaml:"policyExclusions"`
+	PolicyLists      []ConfigPolicyList     `yaml:"policyLists"`
 	Metrics          []ConfigMetric         `yaml:"metrics"`
 	K8SApiConfig     K8SApiConfig           `yaml:"kubernetesAPIClient"`
 }
@@ -141,6 +142,13 @@ type ClusterDiscovery struct {
 type ConfigPolicyExclusions struct {
 	Policies     []string `yaml:"policies"`
 	PolicyGroups []string `yaml:"policyGroups"`
+	PolicyLists  []string `yaml:"policyLists"`
+}
+
+// ConfigPolicyList defines a named, reusable set of policy package names.
+type ConfigPolicyList struct {
+	Name     string   `yaml:"name"`
+	Policies []string `yaml:"policies"`
 }
 
 type K8SApiConfig struct {
@@ -180,6 +188,7 @@ func ValidateClusterCheckConfig(config Config) error {
 	var errors = make([]error, 0)
 	errors = append(errors, validateClustersConfig(config)...)
 	errors = append(errors, validatePolicySourceConfig(config.Policies)...)
+	errors = append(errors, validatePolicyListsConfig(config)...)
 	errors = append(errors, validateOutputConfig(config.Outputs)...)
 	if config.Inputs.GKEApi == nil && config.Inputs.GKELocalInput == nil {
 		errors = append(errors, fmt.Errorf("either gkeAPI input or gkeLocalInput has to be declared"))
@@ -205,6 +214,7 @@ func ValidateClusterCheckConfig(config Config) error {
 
 func ValidatePolicyCheckConfig(config Config) error {
 	errors := validatePolicySourceConfig(config.Policies)
+	errors = append(errors, validatePolicyListsConfig(config)...)
 	if len(errors) > 0 {
 		for _, err := range errors {
 			log.Warnf("configuration validation error: %s", err)
@@ -217,6 +227,7 @@ func ValidatePolicyCheckConfig(config Config) error {
 func ValidateGeneratePolicyDocsConfig(config Config) error {
 	var errors = make([]error, 0)
 	errors = append(errors, validatePolicySourceConfig(config.Policies)...)
+	errors = append(errors, validatePolicyListsConfig(config)...)
 	if len(config.Outputs) != 1 {
 		errors = append(errors, fmt.Errorf("specify output file"))
 	}
@@ -233,6 +244,7 @@ func ValidateScalabilityCheckConfig(config Config) error {
 	var errors = make([]error, 0)
 	errors = append(errors, validateClustersConfig(config)...)
 	errors = append(errors, validatePolicySourceConfig(config.Policies)...)
+	errors = append(errors, validatePolicyListsConfig(config)...)
 	errors = append(errors, validateOutputConfig(config.Outputs)...)
 	if config.Inputs.MetricsAPI == nil || !config.Inputs.MetricsAPI.Enabled {
 		errors = append(errors, fmt.Errorf("metricsAPI input has to be enabled"))
@@ -320,6 +332,87 @@ func validatePolicySourceConfig(policies []ConfigPolicy) []error {
 		}
 	}
 	return errors
+}
+
+func validatePolicyListsConfig(config Config) []error {
+	var errors = make([]error, 0)
+	policyListsByName := make(map[string]ConfigPolicyList, len(config.PolicyLists))
+	for i, policyList := range config.PolicyLists {
+		if policyList.Name == "" {
+			errors = append(errors, fmt.Errorf("policy list [%v]: name is not set", i))
+			continue
+		}
+		if _, ok := policyListsByName[policyList.Name]; ok {
+			errors = append(errors, fmt.Errorf("policy list [%v]: duplicate name %q", i, policyList.Name))
+			continue
+		}
+		if len(policyList.Policies) < 1 {
+			errors = append(errors, fmt.Errorf("policy list [%v]: policies are not set", i))
+			continue
+		}
+		for j, policy := range policyList.Policies {
+			if policy == "" {
+				errors = append(errors, fmt.Errorf("policy list [%v]: policy [%v] is not set", i, j))
+			}
+		}
+		policyListsByName[policyList.Name] = policyList
+	}
+	for i, name := range config.PolicyExclusions.PolicyLists {
+		if name == "" {
+			errors = append(errors, fmt.Errorf("policy exclusion list reference [%v]: name is not set", i))
+			continue
+		}
+		if _, ok := policyListsByName[name]; !ok {
+			errors = append(errors, fmt.Errorf("policy exclusion list reference [%v]: policy list %q is not defined", i, name))
+		}
+	}
+	return errors
+}
+
+// ResolvePolicyExclusions expands named policy lists into explicit policy exclusions.
+func ResolvePolicyExclusions(config *Config) error {
+	if config == nil {
+		return nil
+	}
+	if errors := validatePolicyListsConfig(*config); len(errors) > 0 {
+		for _, err := range errors {
+			log.Warnf("configuration validation error: %s", err)
+		}
+		return errors[0]
+	}
+	if len(config.PolicyExclusions.PolicyLists) < 1 {
+		return nil
+	}
+	policyListsByName := make(map[string]ConfigPolicyList, len(config.PolicyLists))
+	for _, policyList := range config.PolicyLists {
+		policyListsByName[policyList.Name] = policyList
+	}
+	policies := appendUniqueStrings(nil, config.PolicyExclusions.Policies)
+	for _, name := range config.PolicyExclusions.PolicyLists {
+		policies = appendUniqueStrings(policies, policyListsByName[name].Policies)
+	}
+	config.PolicyExclusions.Policies = policies
+	return nil
+}
+
+func appendUniqueStrings(dst []string, values []string) []string {
+	seen := make(map[string]bool, len(dst)+len(values))
+	result := make([]string, 0, len(dst)+len(values))
+	for _, value := range dst {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
 }
 
 func validateOutputConfig(outputs []ConfigOutput) []error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,6 +33,8 @@ func TestReadConfig(t *testing.T) {
 	policy2Repository := "https://github.com/test/test"
 	policy2Branch := "test"
 	policy2Directory := "policies"
+	policyListName := "baseline"
+	policyListPolicy := "gke.policy.private_cluster"
 	clusterDiscoveryEnabled := true
 	clusterDiscoveryOrg := "123456789"
 	clusterDiscoveryProject := "myProject"
@@ -49,6 +51,10 @@ func TestReadConfig(t *testing.T) {
 		"- repository: %s\n"+
 		"  branch: %s\n"+
 		"  directory: %s\n"+
+		"policyLists:\n"+
+		"- name: %s\n"+
+		"  policies:\n"+
+		"  - %s\n"+
 		"clusterDiscovery:\n"+
 		"  enabled: %v\n"+
 		"  organization: %s\n"+
@@ -59,6 +65,7 @@ func TestReadConfig(t *testing.T) {
 		silent, credsFile,
 		cluster1Name, cluster1Location, cluster1Project, cluster2Id,
 		policy1Directory, policy2Repository, policy2Branch, policy2Directory,
+		policyListName, policyListPolicy,
 		clusterDiscoveryEnabled, clusterDiscoveryOrg, clusterDiscoveryProject, clusterDiscoveryFolder,
 	)
 	readFn := func(path string) ([]byte, error) {
@@ -107,6 +114,18 @@ func TestReadConfig(t *testing.T) {
 	}
 	if config.Policies[1].GitDirectory != policy2Directory {
 		t.Errorf("config policies[1] gitDirectory = %v; want %v", config.Policies[1].GitDirectory, policy2Directory)
+	}
+	if len(config.PolicyLists) != 1 {
+		t.Fatalf("config policy lists length = %v; want %v", len(config.PolicyLists), 1)
+	}
+	if config.PolicyLists[0].Name != policyListName {
+		t.Errorf("config policyLists[0] name = %v; want %v", config.PolicyLists[0].Name, policyListName)
+	}
+	if len(config.PolicyLists[0].Policies) != 1 {
+		t.Fatalf("config policyLists[0] policies length = %v; want %v", len(config.PolicyLists[0].Policies), 1)
+	}
+	if config.PolicyLists[0].Policies[0] != policyListPolicy {
+		t.Errorf("config policyLists[0] policies[0] = %v; want %v", config.PolicyLists[0].Policies[0], policyListPolicy)
 	}
 	if config.ClusterDiscovery.Enabled != clusterDiscoveryEnabled {
 		t.Errorf("config clusterDiscovery = %v; want %v", config.ClusterDiscovery.Enabled, clusterDiscoveryEnabled)
@@ -221,6 +240,12 @@ func TestValidatePolicyCheckConfig(t *testing.T) {
 			{LocalDirectory: "./directory"},
 			{GitRepository: "repo", GitBranch: "main", GitDirectory: "./dir"},
 		},
+		PolicyExclusions: ConfigPolicyExclusions{
+			PolicyLists: []string{"baseline"},
+		},
+		PolicyLists: []ConfigPolicyList{
+			{Name: "baseline", Policies: []string{"gke.policy.cluster_binary_authorization"}},
+		},
 	}
 	if err := ValidatePolicyCheckConfig(config); err != nil {
 		t.Errorf("expected no error, got: %v", err)
@@ -239,6 +264,14 @@ func TestValidatePolicyCheckConfig_negative(t *testing.T) {
 			},
 		},
 		{},
+		{
+			Policies: []ConfigPolicy{
+				{LocalDirectory: "./directory"},
+			},
+			PolicyExclusions: ConfigPolicyExclusions{
+				PolicyLists: []string{"missing"},
+			},
+		},
 	}
 
 	for i, config := range badConfigs {
@@ -246,6 +279,78 @@ func TestValidatePolicyCheckConfig_negative(t *testing.T) {
 			t.Errorf("expected error on invalid cluster config [%d]", i)
 		}
 	}
+}
+
+func TestValidatePolicyListsConfig(t *testing.T) {
+	config := Config{
+		PolicyExclusions: ConfigPolicyExclusions{
+			PolicyLists: []string{"baseline", "strict"},
+		},
+		PolicyLists: []ConfigPolicyList{
+			{Name: "baseline", Policies: []string{"gke.policy.cluster_binary_authorization"}},
+			{Name: "strict", Policies: []string{"gke.policy.private_cluster"}},
+		},
+	}
+	if errors := validatePolicyListsConfig(config); len(errors) > 0 {
+		t.Fatalf("expected no error, got: %v", errors)
+	}
+}
+
+func TestValidatePolicyListsConfig_negative(t *testing.T) {
+	inputs := []Config{
+		{
+			PolicyLists: []ConfigPolicyList{{Policies: []string{"gke.policy.private_cluster"}}},
+		},
+		{
+			PolicyLists: []ConfigPolicyList{
+				{Name: "baseline", Policies: []string{"gke.policy.private_cluster"}},
+				{Name: "baseline", Policies: []string{"gke.policy.workload_identity"}},
+			},
+		},
+		{
+			PolicyLists: []ConfigPolicyList{{Name: "empty"}},
+		},
+		{
+			PolicyLists: []ConfigPolicyList{{Name: "empty-policy", Policies: []string{""}}},
+		},
+		{
+			PolicyExclusions: ConfigPolicyExclusions{PolicyLists: []string{""}},
+		},
+		{
+			PolicyExclusions: ConfigPolicyExclusions{PolicyLists: []string{"missing"}},
+			PolicyLists:      []ConfigPolicyList{{Name: "baseline", Policies: []string{"gke.policy.private_cluster"}}},
+		},
+	}
+
+	for i, input := range inputs {
+		if errors := validatePolicyListsConfig(input); len(errors) == 0 {
+			t.Errorf("expected error on invalid policy list config [%d]", i)
+		}
+	}
+}
+
+func TestResolvePolicyExclusions(t *testing.T) {
+	config := &Config{
+		PolicyExclusions: ConfigPolicyExclusions{
+			Policies:    []string{"gke.policy.cluster_binary_authorization", "gke.policy.private_cluster"},
+			PolicyLists: []string{"baseline", "strict"},
+		},
+		PolicyLists: []ConfigPolicyList{
+			{Name: "baseline", Policies: []string{"gke.policy.private_cluster", "gke.policy.workload_identity"}},
+			{Name: "strict", Policies: []string{"gke.policy.secret_encryption"}},
+		},
+	}
+
+	if err := ResolvePolicyExclusions(config); err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	expected := []string{
+		"gke.policy.cluster_binary_authorization",
+		"gke.policy.private_cluster",
+		"gke.policy.workload_identity",
+		"gke.policy.secret_encryption",
+	}
+	assert.Equal(t, expected, config.PolicyExclusions.Policies)
 }
 
 func TestValidateOutputConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add named reusable policy lists to configuration.
- Allow `policyExclusions.policyLists` to expand named lists into explicit policy exclusions.
- Validate missing, duplicate, empty, and undefined policy list references.
- Document the new configuration shape in the user guide.

## Validation

- `make build`
- `make test`
- `go test ./...`
- `make fmtcheck`
- `make vet`
- `staticcheck ./...`
- `npx --yes markdownlint-cli@0.44.0 --config .markdownlint.yml docs/user-guide.md`
- `git diff --check`

Closes #70
