### PR TITLE
Fix control plane access for private endpoints

### DIFF
--- a/gke-policies-v2/policy/control_plane_access.rego
+++ b/gke-policies-v2/policy/control_plane_access.rego
@@ -32,26 +32,53 @@
 #   dataSource: gke
 package gke.policy.control_plane_access
 
-import future.keywords.if
 import future.keywords.contains
+import future.keywords.if
 
 default valid := false
 
 valid if {
-  count(violation) == 0
+	count(violation) == 0
+}
+
+# Authorized networks only apply when a public control plane endpoint exists.
+public_endpoint_disabled if {
+	input.data.gke.private_cluster_config.enable_private_endpoint
+}
+
+public_endpoint_disabled if {
+	input.data.gke.control_plane_endpoints_config.ip_endpoints_config.enabled == false
+}
+
+public_endpoint_disabled if {
+	input.data.gke.control_plane_endpoints_config.ip_endpoints_config.enable_public_endpoint == false
+}
+
+authorized_networks_enabled if {
+	input.data.gke.master_authorized_networks_config.enabled
+}
+
+authorized_networks_enabled if {
+	input.data.gke.control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config.enabled
+}
+
+authorized_networks_cidrs_configured if {
+	count(input.data.gke.master_authorized_networks_config.cidr_blocks) > 0
+}
+
+authorized_networks_cidrs_configured if {
+	count(input.data.gke.control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config.cidr_blocks) > 0
 }
 
 violation contains msg if {
-  not input.data.gke.master_authorized_networks_config.enabled
-  msg := "Cluster is not configured with master authorized networks"
+	not public_endpoint_disabled
+	not authorized_networks_enabled
+	msg := "Cluster is not configured with master authorized networks"
 }
 
 violation contains msg if {
-  not input.data.gke.master_authorized_networks_config.cidr_blocks
-  msg := "Cluster is not configured with master authorized networks CIDRs"
-}
-
-violation contains msg if {
-  count(input.data.gke.master_authorized_networks_config.cidr_blocks) < 1
-  msg := "Cluster is not configured with master authorized networks CIDRs"
+	not public_endpoint_disabled
+	authorized_networks_enabled
+	not authorized_networks_cidrs_configured
+	msg := "Cluster is not configured with master authorized networks CIDRs"
 }

--- a/gke-policies-v2/policy/control_plane_access_test.rego
+++ b/gke-policies-v2/policy/control_plane_access_test.rego
@@ -14,33 +14,87 @@
 
 package gke.policy.control_plane_access_test
 
-import future.keywords.if
 import data.gke.policy.control_plane_access
+import future.keywords.if
 
 test_authorized_networks_enabled if {
-    control_plane_access.valid with input as {"data": {"gke": {"name":"test-cluster","master_authorized_networks_config": {
-        "enabled":true,
-        "cidr_blocks":[
-            {"display_name":"Test Block","cidr_block":"192.168.0.0./16"}
-        ]
-    }}}}
+	control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [{
+				"display_name": "Test Block",
+				"cidr_block": "192.168.0.0/16",
+			}],
+		},
+	}}}
 }
 
-test_authoized_networks_missing if {
-    not control_plane_access.valid with input as {"data": {"gke": {"name":"test-cluster"}}}
+test_authorized_networks_missing if {
+	not control_plane_access.valid with input as {"data": {"gke": {"name": "test-cluster"}}}
 }
 
 test_authorized_networks_disabled if {
-    not control_plane_access.valid with input as {"data": {"gke": {"name":"test-cluster","master_authorized_networks_config": {"enabled":false}}}}
+	not control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {"enabled": false},
+	}}}
 }
 
 test_authorized_networks_no_cidrs_block if {
-    not control_plane_access.valid with input as {"data": {"gke": {"name":"test-cluster","master_authorized_networks_config": {"enabled":true}}}}
+	not control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {"enabled": true},
+	}}}
 }
 
 test_authorized_networks_empty_cidrs_block if {
-    not control_plane_access.valid with input as {"data": {"gke": {"name":"test-cluster","master_authorized_networks_config": {
-        "enabled":true,
-        "cidr_blocks":[]
-    }}}}
+	not control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [],
+		},
+	}}}
+}
+
+test_private_endpoint_only_without_authorized_networks if {
+	control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"private_cluster_config": {"enable_private_endpoint": true},
+	}}}
+}
+
+test_public_endpoint_disabled_without_authorized_networks if {
+	control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"enable_public_endpoint": false}},
+	}}}
+}
+
+test_ip_endpoints_disabled_without_authorized_networks if {
+	control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"enabled": false}},
+	}}}
+}
+
+test_authorized_networks_enabled_on_control_plane_endpoints_config if {
+	control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [{
+				"display_name": "Test Block",
+				"cidr_block": "192.168.0.0/16",
+			}],
+		}}},
+	}}}
+}
+
+test_authorized_networks_on_control_plane_endpoints_config_no_cidrs_block if {
+	not control_plane_access.valid with input as {"data": {"gke": {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"authorized_networks_config": {"enabled": true}}},
+	}}}
 }

--- a/gke-policies/policy/control_plane_access.rego
+++ b/gke-policies/policy/control_plane_access.rego
@@ -32,26 +32,53 @@
 #   dataSource: gke
 package gke.policy.control_plane_access
 
-import future.keywords.if
 import future.keywords.contains
+import future.keywords.if
 
 default valid := false
 
 valid if {
-  count(violation) == 0
+	count(violation) == 0
+}
+
+# Authorized networks only apply when a public control plane endpoint exists.
+public_endpoint_disabled if {
+	input.private_cluster_config.enable_private_endpoint
+}
+
+public_endpoint_disabled if {
+	input.control_plane_endpoints_config.ip_endpoints_config.enabled == false
+}
+
+public_endpoint_disabled if {
+	input.control_plane_endpoints_config.ip_endpoints_config.enable_public_endpoint == false
+}
+
+authorized_networks_enabled if {
+	input.master_authorized_networks_config.enabled
+}
+
+authorized_networks_enabled if {
+	input.control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config.enabled
+}
+
+authorized_networks_cidrs_configured if {
+	count(input.master_authorized_networks_config.cidr_blocks) > 0
+}
+
+authorized_networks_cidrs_configured if {
+	count(input.control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config.cidr_blocks) > 0
 }
 
 violation contains msg if {
-  not input.master_authorized_networks_config.enabled
-  msg := "Cluster is not configured with master authorized networks"
+	not public_endpoint_disabled
+	not authorized_networks_enabled
+	msg := "Cluster is not configured with master authorized networks"
 }
 
 violation contains msg if {
-  not input.master_authorized_networks_config.cidr_blocks
-  msg := "Cluster is not configured with master authorized networks CIDRs"
-}
-
-violation contains msg if {
-  count(input.master_authorized_networks_config.cidr_blocks) < 1
-  msg := "Cluster is not configured with master authorized networks CIDRs"
+	not public_endpoint_disabled
+	authorized_networks_enabled
+	not authorized_networks_cidrs_configured
+	msg := "Cluster is not configured with master authorized networks CIDRs"
 }

--- a/gke-policies/policy/control_plane_access_test.rego
+++ b/gke-policies/policy/control_plane_access_test.rego
@@ -14,33 +14,87 @@
 
 package gke.policy.control_plane_access_test
 
-import future.keywords.if
 import data.gke.policy.control_plane_access
+import future.keywords.if
 
 test_authorized_networks_enabled if {
-    control_plane_access.valid with input as {"name":"test-cluster","master_authorized_networks_config": {
-        "enabled":true,
-        "cidr_blocks":[
-            {"display_name":"Test Block","cidr_block":"192.168.0.0./16"}
-        ]
-    }}
+	control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [{
+				"display_name": "Test Block",
+				"cidr_block": "192.168.0.0/16",
+			}],
+		},
+	}
 }
 
-test_authoized_networks_missing if {
-    not control_plane_access.valid with input as {"name":"test-cluster"}
+test_authorized_networks_missing if {
+	not control_plane_access.valid with input as {"name": "test-cluster"}
 }
 
 test_authorized_networks_disabled if {
-    not control_plane_access.valid with input as {"name":"test-cluster","master_authorized_networks_config": {"enabled":false}}
+	not control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {"enabled": false},
+	}
 }
 
 test_authorized_networks_no_cidrs_block if {
-    not control_plane_access.valid with input as {"name":"test-cluster","master_authorized_networks_config": {"enabled":true}}
+	not control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {"enabled": true},
+	}
 }
 
-test_authorized_networks_empty_cidrs_block if { 
-    not control_plane_access.valid with input as {"name":"test-cluster","master_authorized_networks_config": {
-        "enabled":true,
-        "cidr_blocks":[]
-    }}
+test_authorized_networks_empty_cidrs_block if {
+	not control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"master_authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [],
+		},
+	}
+}
+
+test_private_endpoint_only_without_authorized_networks if {
+	control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"private_cluster_config": {"enable_private_endpoint": true},
+	}
+}
+
+test_public_endpoint_disabled_without_authorized_networks if {
+	control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"enable_public_endpoint": false}},
+	}
+}
+
+test_ip_endpoints_disabled_without_authorized_networks if {
+	control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"enabled": false}},
+	}
+}
+
+test_authorized_networks_enabled_on_control_plane_endpoints_config if {
+	control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"authorized_networks_config": {
+			"enabled": true,
+			"cidr_blocks": [{
+				"display_name": "Test Block",
+				"cidr_block": "192.168.0.0/16",
+			}],
+		}}},
+	}
+}
+
+test_authorized_networks_on_control_plane_endpoints_config_no_cidrs_block if {
+	not control_plane_access.valid with input as {
+		"name": "test-cluster",
+		"control_plane_endpoints_config": {"ip_endpoints_config": {"authorized_networks_config": {"enabled": true}}},
+	}
 }


### PR DESCRIPTION
## Summary
- skip master authorized network checks when the cluster has no public control plane endpoint
- support both legacy private endpoint config and the newer control plane endpoint config shape
- add v1/v2 regression tests for private-only, disabled IP endpoint, and nested authorized-network configs

## Root cause
The policy always required master authorized network CIDRs, even when the public control plane endpoint was disabled. Authorized networks constrain public endpoint access, so private-only clusters were reported invalid incorrectly.

## Validation
- /tmp/opa test gke-policies -v
- /tmp/opa test gke-policies-v2 -v
- /tmp/regal lint --format github gke-policies-v2
- go test ./...

Closes #227